### PR TITLE
fix: 'permission denied' error on linux

### DIFF
--- a/install-linux-mac.sh
+++ b/install-linux-mac.sh
@@ -176,10 +176,10 @@ install_homebrew() {
       run_command "(echo 'eval \"\$(/opt/homebrew/bin/brew shellenv)\"' >> $USER_HOME/.config/fish/config.fish)"
       run_command "eval \"\$(/opt/homebrew/bin/brew shellenv)\""
     elif [ "$os_choice" = "linux" ]; then
-      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> $USER_HOME/.zshrc)"
-      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> $USER_HOME/.bashrc)"
-      run_command "mkdir -p $USER_HOME/.config/fish"
-      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> $USER_HOME/.config/fish/config.fish)"
+      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> ~/.zshrc)"
+      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> ~/.bashrc)"
+      run_command "mkdir -p ~/.config/fish"
+      run_command "(echo 'eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> ~/.config/fish/config.fish)"
       run_command "eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
     fi
   else


### PR DESCRIPTION
Fixed an issue where, during the installation of the script, a "Permission denied" error appeared due to attempting to make changes in the root directory instead of the user directory.