### PR TITLE
fix(deps): add wget deps for avoid error on font download

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,19 @@ git clone https://github.com/Gentleman-Programming/Gentleman.Dots.git
 ```bash
 cd Gentleman.Dots
 ```
+#### 2. Install Homebrew (if not installed on macOS)
 
-#### 2. Install Shell Enhancements
+- **If you already have Homebrew installed, you can skip this step.**
+- Run the following command in your terminal to install Homebrew:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+- Follow the on-screen instructions to complete the installation.
+
+
+#### 3. Install Shell Enhancements
 
 To enhance your shell experience, we recommend installing the following tools, regardless of which shell you are using:
 
@@ -309,16 +320,7 @@ mkdir -p ~/.local/share/atuin
 
 **Note:** Configuration steps for these tools are included in the repository files and will be applied automatically when you copy the configuration files.
 
-#### 3. Install Homebrew (if not installed on macOS)
 
-- **If you already have Homebrew installed, you can skip this step.**
-- Run the following command in your terminal to install Homebrew:
-
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-- Follow the on-screen instructions to complete the installation.
 
 #### 4. Install Iosevka Term Nerd Font
 

--- a/install-linux-mac.sh
+++ b/install-linux-mac.sh
@@ -132,7 +132,7 @@ is_arch() {
 install_dependencies() {
   if is_arch; then
     run_command "sudo pacman -Syu --noconfirm"
-    run_command "sudo pacman -S --needed --noconfirm base-devel curl file git"
+    run_command "sudo pacman -S --needed --noconfirm base-devel curl file git wget"
     run_command "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
     run_command ". $HOME/.cargo/env"
   else


### PR DESCRIPTION
When you try to install the font from the script on a clean arch install it throw an error that wget isn't found. 
![image](https://github.com/user-attachments/assets/bf606df2-f5d2-43f0-ade3-dd8e4fb12587)

I have added it as a installation dependency for avoid the crash