### PR TITLE
fix(deps): add wget dependency on Arch for avoid error on font download

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Before starting the configuration, you need to install some essential dependenci
 
    ```bash
    sudo pacman -Syu --noconfirm
-   sudo pacman -S --needed --noconfirm base-devel curl file git
+   sudo pacman -S --needed --noconfirm base-devel curl file git wget
    ```
 
 2. **Install Rustup (the Rust toolchain installer):**

--- a/install-linux-mac.sh
+++ b/install-linux-mac.sh
@@ -132,7 +132,7 @@ is_arch() {
 install_dependencies() {
   if is_arch; then
     run_command "sudo pacman -Syu --noconfirm"
-    run_command "sudo pacman -S --needed --noconfirm base-devel curl file git"
+    run_command "sudo pacman -S --needed --noconfirm base-devel curl file git wget"
     run_command "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
     run_command ". $HOME/.cargo/env"
   else


### PR DESCRIPTION
When you try to install the font from the script on a clean arch install it throw an error that wget isn't found.
image
![image](https://github.com/user-attachments/assets/72eda6ed-8f98-4fa1-9c2e-e589d3597413)

I have added it as a installation dependency for avoid the crash