### PR TITLE
fix integration with system clipboard

### DIFF
--- a/GentlemanNvim/nvim/lua/config/lazy.lua
+++ b/GentlemanNvim/nvim/lua/config/lazy.lua
@@ -13,22 +13,6 @@ end
 -- Prepend the lazy.nvim path to the runtime path
 vim.opt.rtp:prepend(vim.env.LAZY or lazypath)
 
--- Fix copy and paste in WSL (Windows Subsystem for Linux)
-if vim.fn.has("wsl") == 1 then
-  vim.g.clipboard = {
-    name = "win32yank", -- Use win32yank for clipboard operations
-    copy = {
-      ["+"] = "win32yank.exe -i --crlf", -- Command to copy to the system clipboard
-      ["*"] = "win32yank.exe -i --crlf", -- Command to copy to the primary clipboard
-    },
-    paste = {
-      ["+"] = "win32yank.exe -o --lf", -- Command to paste from the system clipboard
-      ["*"] = "win32yank.exe -o --lf", -- Command to paste from the primary clipboard
-    },
-    cache_enabled = false, -- Disable clipboard caching
-  }
-end
-
 -- Setup lazy.nvim with the specified configuration
 require("lazy").setup({
   spec = {

--- a/README.md
+++ b/README.md
@@ -123,31 +123,21 @@ If WezTerm doesn't take the initial configuration:
 Copy-Item -Path GentlemanKitty\* -Destination $HOME\.config\kitty -Recurse
 ```
 
-#### 7. Install Chocolatey and win32yank
+#### 7. Clipboard Integration Guide
 
-**Chocolatey** is a package manager for Windows that simplifies the installation of software.
+To integrate clipboard functionality into Windows, you need to install a provider.
 
-**To install Chocolatey:**
+- **For Ubuntu**: Install with the following command:
+  ```bash
+  sudo apt install xclip
+  ```
+- **For Arch Linux**: Install with the following command:
+  ```bash
+  sudo pacman -S wl-clipboard
+  ```
 
-- Open **PowerShell** as an administrator.
-- Run the following command:
-
-```powershell
-Set-ExecutionPolicy Bypass -Scope Process -Force; `
-[System.Net.ServicePointManager]::SecurityProtocol = `
-[System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
-iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex
-```
-
-**To install win32yank:**
-
-- After installing Chocolatey, run:
-
-```powershell
-choco install win32yank
-```
-
-**Note:** `win32yank` is required for clipboard integration in Neovim when using WSL.
+**Note:** This ensures that Neovim clipboard integration works automatically with the system without needing additional configurations
+in the `lazy.lua` file.
 
 ---
 


### PR DESCRIPTION
No es necesario instalar win32yank para integrar el clipboard del sistema con el de Neovim en WSL. Solo es necesario instalar un proveedor como se indica en el README.md

- Funciona para Windows con WSL y Linux.
- En caso de usar una distribución distinta a Ubuntu o Arch Linux, solo instale su equivalente.
