### PR TITLE
fix(ui.lua): defer fzf-lua.actions require until after setup

### DIFF
--- a/GentlemanNvim/nvim/lua/plugins/ui.lua
+++ b/GentlemanNvim/nvim/lua/plugins/ui.lua
@@ -1,8 +1,6 @@
 -- This file contains the configuration for various UI-related plugins in Neovim.
 vim.api.nvim_set_hl(0, "SnacksDashboardHeader", { fg = "#c34043", bold = true }) -- color kanagawa dragon red
 
-local actions = require("fzf-lua.actions")
-
 return {
   -- Plugin: fzf-lua
   -- URL: https://github.com/ibhagwan/fzf-lua
@@ -11,6 +9,7 @@ return {
     "ibhagwan/fzf-lua",
     dependencies = { "nvim-tree/nvim-web-devicons" },
     opts = function(_, opts)
+      local actions = require("fzf-lua.actions")
       opts.files["actions"] = {
         ["ctrl-i"] = { actions.toggle_ignore },
         ["ctrl-h"] = { actions.toggle_hidden },


### PR DESCRIPTION
Move the 'require("fzf-lua.actions")' statement inside the configuration function to prevent initialization errors during first-time Neovim setup.

[Problem]
When the configuration is first run, fzf-lua might not be installed yet, causing the top-level 'require' call to fail.

[Solution]
Wrap the require statement within the plugin's setup function to ensure the dependency is only loaded after the plugin manager has installed fzf-lua.

[Outcome]
Prevents startup errors that occurred when initializing the Neovim configuration before all dependencies were fully installed.