### PR TITLE
Fix transparent.nvim warning by updating configuration options

### DIFF
--- a/GentlemanNvim/nvim/lua/plugins/colorscheme.lua
+++ b/GentlemanNvim/nvim/lua/plugins/colorscheme.lua
@@ -4,7 +4,7 @@ return {
       "xiyaowong/transparent.nvim",
       config = function()
         require("transparent").setup({
-          enable = true, -- boolean: enable transparent
+          -- enable = true, -- boolean: enable transparent
           extra_groups = { -- table/string: additional groups that should be cleared
             "Normal",
             "NormalNC",
@@ -29,7 +29,7 @@ return {
             "CursorLineNr",
             "EndOfBuffer",
           },
-          exclude = {}, -- table: groups you don't want to clear
+          exclude_groups = {}, -- table: groups you don't want to clear
         })
         vim.cmd("TransparentEnable") -- execute the command to enable transparency
       end,


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/5c979ce9-6c8b-4ecc-af83-d5991c7eba6b)

- Renamed "exclude" to "exclude_groups" in the config.
- Removed the deprecated "enable" option from the config.

This resolves the warning message in the Neovim terminal.