### PR TITLE
fix: replacing deprecated commands in bash-env.nu

### DIFF
--- a/bash-env.nu
+++ b/bash-env.nu
@@ -19,7 +19,7 @@ export def main [
   let raw = ($in | str join "\n") | bash-env-json ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 
-  let error = $raw_json | get -i error
+  let error = $raw_json | get -o error
   if $error != null {
     error make { msg: $error }
   } else if $raw.exit_code != 0 {
@@ -28,7 +28,7 @@ export def main [
 
   if ($export | is-not-empty) {
     print "warning: --export is deprecated, use --shellvars(-s) instead"
-    let exported_shellvars = ($raw_json.shellvars | select -i ...$export)
+    let exported_shellvars = ($raw_json.shellvars | select -o ...$export)
     $raw_json.env | merge ($exported_shellvars)
   } else if $shellvars or ($fn | is-not-empty) {
     $raw_json


### PR DESCRIPTION
I replaced two deprecated commands in the bash-env.nu file that was displayed when I opened the terminal.

<img width="1450" height="332" alt="Captura de pantalla 2025-08-15 153003" src="https://github.com/user-attachments/assets/247be1f1-ac8b-46ae-b52c-5a9a006c7cd1" />
