### PR TITLE
Fix: remove deprecated tap option to install font in macos

### DIFF
--- a/install-linux-mac.sh
+++ b/install-linux-mac.sh
@@ -363,7 +363,6 @@ else
         unzip ~/.local/share/fonts/IosevkaTerm.zip -d ~/.local/share/fonts/
         fc-cache -fv
       elif [ "$os_choice" = "mac" ]; then
-        brew tap homebrew/cask-fonts
         brew install --cask font-iosevka-term-nerd-font
       fi
       echo -e "${GREEN}Iosevka Term Nerd Font installed.${NC}"


### PR DESCRIPTION
There is an error when installing the font because previously fonts were installed from the homebrew/cask-fonts tap, but that repository has been deprecated and emptied (it no longer exists there)