### PR TITLE
[fix] update horizontal movements level 3

### DIFF
--- a/installer/internal/tui/trainer/exercises.go
+++ b/installer/internal/tui/trainer/exercises.go
@@ -223,7 +223,7 @@ func getHorizontalLessons() []Exercise {
 			Level:       3,
 			Type:        ExerciseLesson,
 			Code:        []string{"const userName = 'gentleman';"},
-			CursorPos:   Position{Line: 0, Col: 28},
+			CursorPos:   Position{Line: 0, Col: 27},
 			Mission:     "Move backwards to the first quote using F'",
 			Solutions:   []string{"F'"},
 			Optimal:     "F'",


### PR DESCRIPTION
Problem: Proposed solution is `F'` to get into the first quote but doing that would lead you into the last quote

Solution: since string positions is 0-indexed, last quote start should be 27 in order to use F' and get to the first quote
<img width="1486" height="142" alt="image" src="https://github.com/user-attachments/assets/8ae49df1-84ff-4924-9842-e97636ee6161" />
