### PR TITLE
Fix Fish startup error in WSL by using xterm-256color instead of wezterm

### DIFF
--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -45,7 +45,14 @@ config.cursor_blink_ease_out = "Constant"
 -- └──────────────────────────────────────────────────────────────────────────────┘
 
 -- Terminal & Colors
-config.term = "wezterm"
+if wezterm.target_triple:find("windows") then
+  -- WSL
+  config.term = "xterm-256color"
+else
+  -- Native Linux / macOS
+  config.term = "wezterm"
+end
+
 config.enable_csi_u_key_encoding = true
 
 -- Undercurl support (LSP diagnostics, spelling)


### PR DESCRIPTION
This PR fixes an issue when using WezTerm on Windows with WSL, where Fish fails to start if TERM is set to wezterm.

In WSL environments, the wezterm terminfo entry is not available by default, which causes Fish to exit with:
`missing or unsuitable terminal: wezterm`