### PR TITLE
Fix dashboard key conflict with flash.nvim

### DIFF
--- a/GentlemanNvim/nvim/lua/plugins/ui.lua
+++ b/GentlemanNvim/nvim/lua/plugins/ui.lua
@@ -264,7 +264,7 @@ return {
           -- stylua: ignore
           ---@type snacks.dashboard.Item[]
           keys = {
-            { icon = " ", key = "f", desc = "Find File", action = ":lua Snacks.dashboard.pick('files')" },
+            { icon = " ", key = "<leader><leader>", desc = "Find File", action = ":lua Snacks.dashboard.pick('files')" },
             { icon = " ", key = "n", desc = "New File", action = ":ene | startinsert" },
             { icon = " ", key = "g", desc = "Find Text", action = ":lua Snacks.dashboard.pick('live_grep')" },
             { icon = " ", key = "r", desc = "Recent Files", action = ":lua Snacks.dashboard.pick('oldfiles')" },


### PR DESCRIPTION
This PR remaps the Snacks dashboard “Find File” action from f to <leader><leader> to avoid key conflicts with flash.nvim.