### PR TITLE
fix(homebrew): use temp file and NONINTERACTIVE=1 for Linux/WSL install

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -154,7 +154,27 @@ func stepInstallHomebrew(m *Model) error {
 	}
 
 	SendLog(stepID, "Installing Homebrew package manager...")
-	result := system.RunWithLogs(`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`, nil, func(line string) {
+
+	// Download the installer to a temp file to ensure it runs with bash explicitly.
+	// Using command substitution (/bin/bash -c "$(curl ...)") can fail in non-TTY
+	// environments because the script may not detect bash correctly.
+	tmpScript := filepath.Join(os.TempDir(), "homebrew_install.sh")
+	dlResult := system.Run(
+		fmt.Sprintf("curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o %s", tmpScript),
+		nil,
+	)
+	if dlResult.Error != nil {
+		return wrapStepError("homebrew", "Download Homebrew installer",
+			"Failed to download Homebrew installer. Check your internet connection.",
+			dlResult.Error)
+	}
+	defer os.Remove(tmpScript)
+
+	// Run with NONINTERACTIVE=1 to prevent post-install prompts from exiting
+	// with status 1 in non-TTY environments (e.g. piped stdout/stderr in TUI mode).
+	result := system.RunWithLogs("/bin/bash "+tmpScript, &system.ExecOptions{
+		Env: []string{"NONINTERACTIVE=1"},
+	}, func(line string) {
 		SendLog(stepID, line)
 	})
 	if result.Error != nil {


### PR DESCRIPTION
## Problem

On Linux and WSL, the Homebrew installation step fails with two different errors:

1. `Bash is required to interpret this script.` — the Homebrew installer doesn't detect bash correctly when run via command substitution in a non-TTY environment.
2. `Install Homebrew failed: exit status 1` — post-install prompts exit with status 1 when stdin/stdout are piped (TUI mode), even though Homebrew installed successfully.

Both issues are reported in #137.

## Root Cause

The current code:
```go
system.RunWithLogs(`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`, nil, ...)
```

`RunWithLogs` wraps this command with `GetShell() -c command`, so the effective execution is:
```
/bin/bash -c '/bin/bash -c "$(curl ...)"'
```

In non-TTY environments (where the TUI pipes stdout/stderr), the Homebrew script can fail to detect it's running under bash, and interactive post-install prompts receive EOF on stdin, exiting with status 1.

## Fix

1. **Download the installer to a temp file** — ensures the script is always run as a file with explicit `/bin/bash`, not via command substitution where shell detection can fail.
2. **Set `NONINTERACTIVE=1`** — the official Homebrew flag to skip all interactive prompts, preventing false-positive failures when stdin is not a TTY.

## Test plan

- [ ] Run installer on Linux (Ubuntu/Debian) without Homebrew installed
- [ ] Run installer on WSL
- [ ] Verify Homebrew installs successfully without the `Bash is required` error
- [ ] Verify no `exit status 1` false failure after successful install