### PR TITLE
fix(homebrew): use bash and NONINTERACTIVE=1 in interactive install script

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -154,27 +154,7 @@ func stepInstallHomebrew(m *Model) error {
 	}
 
 	SendLog(stepID, "Installing Homebrew package manager...")
-
-	// Download the installer to a temp file to ensure it runs with bash explicitly.
-	// Using command substitution (/bin/bash -c "$(curl ...)") can fail in non-TTY
-	// environments because the script may not detect bash correctly.
-	tmpScript := filepath.Join(os.TempDir(), "homebrew_install.sh")
-	dlResult := system.Run(
-		fmt.Sprintf("curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o %s", tmpScript),
-		nil,
-	)
-	if dlResult.Error != nil {
-		return wrapStepError("homebrew", "Download Homebrew installer",
-			"Failed to download Homebrew installer. Check your internet connection.",
-			dlResult.Error)
-	}
-	defer os.Remove(tmpScript)
-
-	// Run with NONINTERACTIVE=1 to prevent post-install prompts from exiting
-	// with status 1 in non-TTY environments (e.g. piped stdout/stderr in TUI mode).
-	result := system.RunWithLogs("/bin/bash "+tmpScript, &system.ExecOptions{
-		Env: []string{"NONINTERACTIVE=1"},
-	}, func(line string) {
+	result := system.RunWithLogs(`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`, nil, func(line string) {
 		SendLog(stepID, line)
 	})
 	if result.Error != nil {

--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -154,7 +154,27 @@ func stepInstallHomebrew(m *Model) error {
 	}
 
 	SendLog(stepID, "Installing Homebrew package manager...")
-	result := system.RunWithLogs(`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`, nil, func(line string) {
+
+	// Download the installer to a temp file to ensure it runs with bash explicitly.
+	// Using command substitution (/bin/bash -c "$(curl ...)") can fail in non-TTY
+	// environments because the script may not detect bash correctly.
+	tmpScript := filepath.Join(os.TempDir(), "homebrew_install.sh")
+	dlResult := system.Run(
+		fmt.Sprintf("curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o %s", tmpScript),
+		nil,
+	)
+	if dlResult.Error != nil {
+		return wrapStepError("homebrew", "Download Homebrew installer",
+			"Failed to download Homebrew installer. Check your internet connection.",
+			dlResult.Error)
+	}
+	defer os.Remove(tmpScript)
+
+	// Run with NONINTERACTIVE=1 to prevent post-install prompts from exiting
+	// with status 1 in non-TTY environments (e.g. piped stdout/stderr in TUI mode).
+	result := system.RunWithLogs("/bin/bash "+tmpScript, &system.ExecOptions{
+		Env: []string{"NONINTERACTIVE=1"},
+	}, func(line string) {
 		SendLog(stepID, line)
 	})
 	if result.Error != nil {

--- a/installer/internal/tui/interactive.go
+++ b/installer/internal/tui/interactive.go
@@ -70,13 +70,13 @@ func getHomebrewScript(m *Model) (string, error) {
 	}
 
 	brewPrefix := system.GetBrewPrefix()
-	script := fmt.Sprintf(`#!/bin/sh
+	script := fmt.Sprintf(`#!/bin/bash
 set -e
 echo ""
 echo "🍺 Installing Homebrew package manager..."
 echo "   (You may be prompted for your password)"
 echo ""
-/bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 echo ""
 echo "📝 Configuring shell to use Homebrew..."


### PR DESCRIPTION
## Problem

On Linux and WSL, the Homebrew installation step fails immediately with:

```
Bash is required to interpret this script.
```

Reported in #137.

## Root Cause

`getHomebrewScript()` in `interactive.go` generates a script with `#!/bin/sh` that calls the Homebrew installer via:

```sh
/bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```

On Debian/Ubuntu (including WSL), `/bin/sh` resolves to **dash**, not bash. Homebrew's `install.sh` checks `$BASH_VERSION` at the very top and aborts if it's empty — which it always is under dash.

## Fix

Two changes in `interactive.go`:

1. Changed shebang from `#!/bin/sh` to `#!/bin/bash`
2. Changed the installer call from `/bin/sh -c "$(curl ...)"` to `NONINTERACTIVE=1 /bin/bash -c "$(curl ...)"`

`NONINTERACTIVE=1` is the official Homebrew flag to skip post-install interactive prompts, which previously caused a false `exit status 1` failure in environments without a TTY.

## Testing

Tested with `Dockerfile.test` on Ubuntu 22.04 — Homebrew installs successfully:

```
==> Running in non-interactive mode because `$NONINTERACTIVE` is set.
==> Checking for `sudo` access...
==> Installation successful!
```

## Notes

During testing, a separate unrelated failure was found: `chsh: PAM: Authentication failure` when changing the default shell in Docker. That will be tracked as a separate issue.