### PR TITLE
fix(setshell): fallback to sudo usermod when chsh fails PAM auth

### DIFF
--- a/installer/internal/tui/interactive.go
+++ b/installer/internal/tui/interactive.go
@@ -327,10 +327,18 @@ echo ""
 echo "🔐 Changing default shell..."
 echo "   (You may need to enter your password)"
 echo ""
-chsh -s "$SHELL_PATH"
+if chsh -s "$SHELL_PATH" 2>/dev/null; then
+    echo ""
+    echo "✅ Default shell changed to $SHELL_PATH"
+elif sudo usermod -s "$SHELL_PATH" "$(whoami)" 2>/dev/null; then
+    echo ""
+    echo "✅ Default shell changed to $SHELL_PATH (via usermod)"
+else
+    echo ""
+    echo "⚠️  Could not change default shell automatically."
+    echo "   Run manually: chsh -s $SHELL_PATH"
+fi
 
-echo ""
-echo "✅ Default shell changed to $SHELL_PATH"
 echo "   Please log out and log back in for changes to take effect."
 echo ""
 echo "Press Enter to continue..."


### PR DESCRIPTION
## Problem

The shell change step fails with:

```
chsh: PAM: Authentication failure
```

This happens in Docker containers, minimal Linux installs, and any environment where PAM authentication is not fully configured — even when the user has full sudo access.

## Root Cause

`getSetShellScript()` uses `chsh -s "$SHELL_PATH"` which requires the user to authenticate via PAM. In environments without a proper PAM setup, this always fails regardless of sudo access.

## Fix

Try `chsh` first (standard behavior on real machines where it works). If it fails, fall back to `sudo usermod -s <shell> $(whoami)` which does not require user PAM authentication. If both fail, show a clear manual instruction instead of crashing.

```sh
if chsh -s "$SHELL_PATH" 2>/dev/null; then
    echo "✅ Default shell changed to $SHELL_PATH"
elif sudo usermod -s "$SHELL_PATH" "$(whoami)" 2>/dev/null; then
    echo "✅ Default shell changed to $SHELL_PATH (via usermod)"
else
    echo "⚠️  Could not change default shell automatically."
    echo "   Run manually: chsh -s $SHELL_PATH"
fi
```

## Testing

Tested with `Dockerfile.test` on Ubuntu 22.04 — full installation now completes successfully:

```
✨ Installation Complete! ✨
  • OS: linux
  • Terminal: alacritty
  • Shell: fish
  • Window Manager: tmux
  • Font: Iosevka Term Nerd Font
  • Editor: Neovim with Gentleman config
```

## Notes

Discovered during testing of PR #148 (Homebrew fix for #137).