### PR TITLE
fix(backup): support symlinked config directories

### DIFF
--- a/docs/tui-installer.md
+++ b/docs/tui-installer.md
@@ -167,8 +167,10 @@ The installer automatically detects existing configurations for:
 Backups are stored in your home directory with a timestamp:
 
 ```
-~/.gentleman-backup-YYYYMMDD-HHMMSS/
+~/.gentleman-backup-YYYY-MM-DD-HHMMSS/
 ```
+
+Directory-based configs such as `~/.oh-my-zsh` are backed up recursively, alongside single-file configs like `~/.zshrc`.
 
 ### Restoring a Backup
 

--- a/installer/internal/system/exec.go
+++ b/installer/internal/system/exec.go
@@ -284,8 +284,19 @@ func RunPkgInstall(packages string, opts *ExecOptions, logFunc func(string)) *Ex
 
 // CopyFile copies a file from src to dst
 func CopyFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("copy file %s: source is a directory", src)
+	}
+
 	input, err := os.ReadFile(src)
 	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
 	return os.WriteFile(dst, input, 0644)
@@ -295,21 +306,44 @@ func CopyFile(src, dst string) error {
 func CopyDir(src, dst string) error {
 	// Clean paths - remove trailing /* or /. if present
 	src = strings.TrimSuffix(strings.TrimSuffix(src, "/*"), "/.")
+	walkRoot, err := filepath.EvalSymlinks(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return err
+		}
+		walkRoot = src
+	}
 
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	rootInfo, err := os.Stat(walkRoot)
+	if err != nil {
+		return err
+	}
+	if !rootInfo.IsDir() {
+		return fmt.Errorf("copy dir %s: source is not a directory", src)
+	}
+	if err := os.MkdirAll(dst, rootInfo.Mode()); err != nil {
+		return err
+	}
+
+	return filepath.Walk(walkRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		resolvedInfo, err := os.Stat(path)
 		if err != nil {
 			return err
 		}
 
 		// Calculate destination path
-		relPath, err := filepath.Rel(src, path)
+		relPath, err := filepath.Rel(walkRoot, path)
 		if err != nil {
 			return err
 		}
 		dstPath := filepath.Join(dst, relPath)
 
-		if info.IsDir() {
-			return os.MkdirAll(dstPath, info.Mode())
+		if resolvedInfo.IsDir() {
+			return os.MkdirAll(dstPath, resolvedInfo.Mode())
 		}
 
 		// Copy file

--- a/installer/internal/system/exec_test.go
+++ b/installer/internal/system/exec_test.go
@@ -160,6 +160,77 @@ func TestCopyFile(t *testing.T) {
 			t.Error("Expected error for non-existent source")
 		}
 	})
+
+	t.Run("should error when source is a directory", func(t *testing.T) {
+		srcDir := t.TempDir()
+		dstFile := filepath.Join(t.TempDir(), "dest.txt")
+
+		err := CopyFile(srcDir, dstFile)
+		if err == nil {
+			t.Error("Expected error when source is a directory")
+		}
+	})
+}
+
+func TestCopyDir(t *testing.T) {
+	t.Run("should copy directory recursively", func(t *testing.T) {
+		srcDir := filepath.Join(t.TempDir(), "src")
+		dstDir := filepath.Join(t.TempDir(), "dst")
+
+		err := os.MkdirAll(filepath.Join(srcDir, "nested"), 0o755)
+		if err != nil {
+			t.Fatalf("Failed to create source directory: %v", err)
+		}
+		err = os.WriteFile(filepath.Join(srcDir, "nested", "config.txt"), []byte("hello"), 0o644)
+		if err != nil {
+			t.Fatalf("Failed to write source file: %v", err)
+		}
+
+		err = CopyDir(srcDir, dstDir)
+		if err != nil {
+			t.Fatalf("Unexpected error copying directory: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dstDir, "nested", "config.txt"))
+		if err != nil {
+			t.Fatalf("Failed to read copied file: %v", err)
+		}
+		if string(data) != "hello" {
+			t.Errorf("Expected copied content 'hello', got %q", string(data))
+		}
+	})
+
+	t.Run("should follow symlink to directory", func(t *testing.T) {
+		realDir := filepath.Join(t.TempDir(), "real")
+		linkDir := filepath.Join(t.TempDir(), "link")
+		dstDir := filepath.Join(t.TempDir(), "dst")
+
+		err := os.MkdirAll(realDir, 0o755)
+		if err != nil {
+			t.Fatalf("Failed to create real directory: %v", err)
+		}
+		err = os.WriteFile(filepath.Join(realDir, "theme.zsh"), []byte("prompt"), 0o644)
+		if err != nil {
+			t.Fatalf("Failed to write real directory file: %v", err)
+		}
+		err = os.Symlink(realDir, linkDir)
+		if err != nil {
+			t.Skipf("Symlinks not supported in this environment: %v", err)
+		}
+
+		err = CopyDir(linkDir, dstDir)
+		if err != nil {
+			t.Fatalf("Unexpected error copying symlinked directory: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dstDir, "theme.zsh"))
+		if err != nil {
+			t.Fatalf("Failed to read copied file from symlinked directory: %v", err)
+		}
+		if string(data) != "prompt" {
+			t.Errorf("Expected copied content 'prompt', got %q", string(data))
+		}
+	})
 }
 
 func TestConfigPaths(t *testing.T) {
@@ -324,6 +395,46 @@ func TestCreateBackup(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("should backup file and symlinked directory configs", func(t *testing.T) {
+		home := t.TempDir()
+		originalHome := os.Getenv("HOME")
+		if err := os.Setenv("HOME", home); err != nil {
+			t.Fatalf("Failed to set HOME: %v", err)
+		}
+		defer os.Setenv("HOME", originalHome)
+
+		realOhMyZsh := filepath.Join(home, "ohmyzsh-real")
+		if err := os.MkdirAll(filepath.Join(realOhMyZsh, "themes"), 0o755); err != nil {
+			t.Fatalf("Failed to create oh-my-zsh directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(realOhMyZsh, "themes", "gentleman.zsh-theme"), []byte("theme"), 0o644); err != nil {
+			t.Fatalf("Failed to create oh-my-zsh file: %v", err)
+		}
+		if err := os.Symlink(realOhMyZsh, filepath.Join(home, ".oh-my-zsh")); err != nil {
+			t.Skipf("Symlinks not supported in this environment: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte("export ZSH=~/.oh-my-zsh\n"), 0o644); err != nil {
+			t.Fatalf("Failed to create .zshrc: %v", err)
+		}
+
+		backupDir, err := CreateBackup([]string{"oh-my-zsh: " + filepath.Join(home, ".oh-my-zsh"), "zsh: " + filepath.Join(home, ".zshrc")})
+		if err != nil {
+			t.Fatalf("Unexpected error creating backup: %v", err)
+		}
+		defer os.RemoveAll(backupDir)
+
+		if _, err := os.Stat(filepath.Join(backupDir, "oh-my-zsh", "themes", "gentleman.zsh-theme")); err != nil {
+			t.Fatalf("Expected backed up oh-my-zsh theme file: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(backupDir, "zsh"))
+		if err != nil {
+			t.Fatalf("Expected backed up zsh file: %v", err)
+		}
+		if !strings.Contains(string(data), "oh-my-zsh") {
+			t.Errorf("Expected zsh backup to contain original content, got %q", string(data))
+		}
+	})
 }
 
 func TestRestoreBackup(t *testing.T) {
@@ -345,6 +456,54 @@ func TestRestoreBackup(t *testing.T) {
 		err := RestoreBackup(testBackupDir)
 		if err != nil {
 			t.Errorf("RestoreBackup should not error for empty backup: %v", err)
+		}
+	})
+
+	t.Run("should restore directory and file configs", func(t *testing.T) {
+		home := t.TempDir()
+		originalHome := os.Getenv("HOME")
+		if err := os.Setenv("HOME", home); err != nil {
+			t.Fatalf("Failed to set HOME: %v", err)
+		}
+		defer os.Setenv("HOME", originalHome)
+
+		backupDir := filepath.Join(home, ".gentleman-backup-restore-test")
+		if err := os.MkdirAll(filepath.Join(backupDir, "oh-my-zsh", "themes"), 0o755); err != nil {
+			t.Fatalf("Failed to create backup directory tree: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(backupDir, "oh-my-zsh", "themes", "gentleman.zsh-theme"), []byte("restored-theme"), 0o644); err != nil {
+			t.Fatalf("Failed to create backed up theme file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(backupDir, "zsh"), []byte("restored-zshrc"), 0o644); err != nil {
+			t.Fatalf("Failed to create backed up zshrc file: %v", err)
+		}
+
+		if err := os.MkdirAll(filepath.Join(home, ".oh-my-zsh"), 0o755); err != nil {
+			t.Fatalf("Failed to create existing oh-my-zsh directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte("old-zshrc"), 0o644); err != nil {
+			t.Fatalf("Failed to create existing zshrc file: %v", err)
+		}
+
+		err := RestoreBackup(backupDir)
+		if err != nil {
+			t.Fatalf("Unexpected error restoring backup: %v", err)
+		}
+
+		themeData, err := os.ReadFile(filepath.Join(home, ".oh-my-zsh", "themes", "gentleman.zsh-theme"))
+		if err != nil {
+			t.Fatalf("Failed to read restored theme: %v", err)
+		}
+		if string(themeData) != "restored-theme" {
+			t.Errorf("Expected restored theme content, got %q", string(themeData))
+		}
+
+		zshrcData, err := os.ReadFile(filepath.Join(home, ".zshrc"))
+		if err != nil {
+			t.Fatalf("Failed to read restored zshrc: %v", err)
+		}
+		if string(zshrcData) != "restored-zshrc" {
+			t.Errorf("Expected restored zshrc content, got %q", string(zshrcData))
 		}
 	})
 }

--- a/installer/internal/tui/installation_steps_test.go
+++ b/installer/internal/tui/installation_steps_test.go
@@ -774,6 +774,47 @@ func TestBackupOptions(t *testing.T) {
 	})
 }
 
+func TestStepBackupConfigs(t *testing.T) {
+	t.Run("backs up symlinked oh-my-zsh directory without failing", func(t *testing.T) {
+		home := t.TempDir()
+		originalHome := os.Getenv("HOME")
+		if err := os.Setenv("HOME", home); err != nil {
+			t.Fatalf("Failed to set HOME: %v", err)
+		}
+		defer os.Setenv("HOME", originalHome)
+
+		realOhMyZsh := filepath.Join(home, "ohmyzsh-real")
+		if err := os.MkdirAll(filepath.Join(realOhMyZsh, "themes"), 0o755); err != nil {
+			t.Fatalf("Failed to create real oh-my-zsh directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(realOhMyZsh, "themes", "gentleman.zsh-theme"), []byte("theme"), 0o644); err != nil {
+			t.Fatalf("Failed to create real oh-my-zsh file: %v", err)
+		}
+		if err := os.Symlink(realOhMyZsh, filepath.Join(home, ".oh-my-zsh")); err != nil {
+			t.Skipf("Symlinks not supported in this environment: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte("export ZSH=~/.oh-my-zsh\n"), 0o644); err != nil {
+			t.Fatalf("Failed to create zshrc: %v", err)
+		}
+
+		m := NewModel()
+		m.ExistingConfigs = []string{
+			"oh-my-zsh: " + filepath.Join(home, ".oh-my-zsh"),
+			"zsh: " + filepath.Join(home, ".zshrc"),
+		}
+
+		err := stepBackupConfigs(&m)
+		if err != nil {
+			t.Fatalf("Expected backup step to succeed, got error: %v", err)
+		}
+		defer os.RemoveAll(m.BackupDir)
+
+		if _, err := os.Stat(filepath.Join(m.BackupDir, "oh-my-zsh", "themes", "gentleman.zsh-theme")); err != nil {
+			t.Fatalf("Expected oh-my-zsh backup to exist: %v", err)
+		}
+	})
+}
+
 // Helper functions
 func simulateKeyPress(m Model, key string) (Model, interface{}) {
 	var msg tea.Msg


### PR DESCRIPTION
## Summary
- fix backup handling for config directories when the source path is a symlink, including `.oh-my-zsh` on macOS
- harden file and directory copy helpers so backup and restore consistently handle file vs directory sources
- add targeted backup tests and update installer docs to reflect recursive directory backups and the real backup naming format

## Validation
- `go build -o gentleman-dots ./cmd/gentleman-installer`
- `go test ./internal/system/...`
- `go test ./internal/system/... -run 'TestCopyDir|TestCreateBackup|TestRestoreBackup'`
- `go test ./internal/tui/... -run TestStepBackupConfigs -v`

## Notes
- the full `./internal/tui/...` suite still has unrelated pre-existing failures around step ordering and a golden menu test; those were left out of scope for this fix