### PR TITLE
fix(nvim): correct Obsidian Quick Switch keymap (quick-switch -> quick_switch)

### DIFF
--- a/GentlemanNvim/nvim/lua/config/keymaps.lua
+++ b/GentlemanNvim/nvim/lua/config/keymaps.lua
@@ -31,7 +31,7 @@ vim.keymap.set("n", "<leader>ob", "<cmd>Obsidian backlinks<CR>", { desc = "Show 
 vim.keymap.set("n", "<leader>ol", "<cmd>Obsidian links<CR>", { desc = "Show Obsidian Links" })
 vim.keymap.set("n", "<leader>on", "<cmd>Obsidian new<CR>", { desc = "Create New Note" })
 vim.keymap.set("n", "<leader>os", "<cmd>Obsidian search<CR>", { desc = "Search Obsidian" })
-vim.keymap.set("n", "<leader>oq", "<cmd>Obsidian quick-switch<CR>", { desc = "Quick Switch" })
+vim.keymap.set("n", "<leader>oq", "<cmd>Obsidian quick_switch<CR>", { desc = "Quick Switch" })
 
 ----- OIL -----
 vim.keymap.set("n", "-", "<CMD>Oil<CR>", { desc = "Open parent directory" })


### PR DESCRIPTION
## What

Fixes the `<leader>oq` (Obsidian Quick Switch) keymap, which was bound to `:Obsidian quick-switch` with a hyphen.

## Why

`obsidian.nvim` registers the subcommand with an **underscore** (`quick_switch`), and command dispatch is a direct table lookup by exact key — there is no hyphen→underscore normalization:

```lua
-- obsidian.nvim/lua/obsidian/commands/init.lua
M.register("quick_switch", { nargs = "?" })

-- handle_command
local cmdconfig = M.commands[cmd]   -- M.commands["quick-switch"] == nil
if cmdconfig == nil then
  log.err("Command '" .. cmd .. "' not found")
  return
end
```

So `:Obsidian quick-switch` errors with `Command 'quick-switch' not found`. All other Obsidian keymaps in that block already use the correct registered names.

## Change

`GentlemanNvim/nvim/lua/config/keymaps.lua` — one line:

```diff
-vim.keymap.set("n", "<leader>oq", "<cmd>Obsidian quick-switch<CR>", { desc = "Quick Switch" })
+vim.keymap.set("n", "<leader>oq", "<cmd>Obsidian quick_switch<CR>", { desc = "Quick Switch" })
```

Closes #160
