### PR TITLE
feat(configs): skip multiplexer auto-launch inside herdr panes

### DIFF
--- a/GentlemanFish/fish/config.fish
+++ b/GentlemanFish/fish/config.fish
@@ -39,11 +39,15 @@ if test $IS_TERMUX -eq 0; and set -q BREW_BIN; and test -f $BREW_BIN
 end
 
 # Start tmux/zellij (tmux first, zellij as fallback)
+# Skip auto-launch inside herdr panes (HERDR_ENV is set) to avoid nested
+# multiplexers. See https://github.com/ogulcancelik/herdr
 if not set -q TMUX
-    if type -q tmux
-        tmux new-session -A -s main
-    else if type -q zellij
-        zellij attach -c main
+    if not set -q HERDR_ENV
+        if type -q tmux
+            tmux new-session -A -s main
+        else if type -q zellij
+            zellij attach -c main
+        end
     end
 end
 

--- a/GentlemanNushell/config.nu
+++ b/GentlemanNushell/config.nu
@@ -925,8 +925,10 @@ def fzfnvim [] {
 let MULTIPLEXER = "tmux" 
 let MULTIPLEXER_ENV_PREFIX = "TMUX"
 
+# Skip auto-launch inside herdr panes (HERDR_ENV is set) to avoid nested
+# multiplexers. See https://github.com/ogulcancelik/herdr
 def start_multiplexer [] {
-  if $MULTIPLEXER_ENV_PREFIX not-in ($env | columns) {
+  if ($MULTIPLEXER_ENV_PREFIX not-in ($env | columns)) and ("HERDR_ENV" not-in ($env | columns)) {
     run-external $MULTIPLEXER
   }
 }

--- a/GentlemanZsh/.zshrc
+++ b/GentlemanZsh/.zshrc
@@ -84,7 +84,10 @@ WM_CMD="tmux"
 # change with zellij
 
 function start_if_needed() {
-    if [[ $- == *i* ]] && [[ -z "${WM_VAR#/}" ]] && [[ -t 1 ]]; then
+    # Skip auto-launch inside herdr panes (HERDR_ENV is set) to avoid nested
+    # multiplexers. See https://github.com/ogulcancelik/herdr
+    if [[ $- == *i* ]] && [[ -z "${WM_VAR#/}" ]] && [[ -t 1 ]] \
+      && [[ -z "$HERDR_ENV" ]]; then
         exec $WM_CMD
     fi
 }

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -425,6 +425,23 @@ else
 end
 ```
 
+### Nested Multiplexer Inside herdr
+
+[herdr](https://github.com/ogulcancelik/herdr) is an agent multiplexer that runs
+each pane as a real shell on top of your terminal. Since the Gentleman shell
+configs auto-launch tmux/zellij on interactive startup, an unguarded config would
+spawn a multiplexer *inside* every herdr pane, nesting one multiplexer in another.
+
+**Status**: ✅ Handled automatically. herdr exports `HERDR_ENV` in its panes, and
+the auto-launch logic skips when that variable is set:
+
+- **Zsh** (`.zshrc`) — `start_if_needed` adds `[[ -z "$HERDR_ENV" ]]`
+- **Fish** (`config.fish`) — the launch block is wrapped in `if not set -q HERDR_ENV`
+- **Nushell** (`config.nu`) — `start_multiplexer` adds `"HERDR_ENV" not-in ($env | columns)`
+
+The guard is multiplexer-agnostic, so it applies whether you chose tmux or zellij.
+If you launch your shell outside herdr, the multiplexer starts as usual.
+
 ### Other Issues
 
 If you encounter other problems:

--- a/installer/internal/system/patch_test.go
+++ b/installer/internal/system/patch_test.go
@@ -22,7 +22,10 @@ WM_CMD="tmux"
 # change with zellij
 
 function start_if_needed() {
-    if [[ $- == *i* ]] && [[ -z "${WM_VAR#/}" ]] && [[ -t 1 ]]; then
+    # Skip auto-launch inside herdr panes (HERDR_ENV is set) to avoid nested
+    # multiplexers. See https://github.com/ogulcancelik/herdr
+    if [[ $- == *i* ]] && [[ -z "${WM_VAR#/}" ]] && [[ -t 1 ]] \
+      && [[ -z "$HERDR_ENV" ]]; then
         exec $WM_CMD
     fi
 }
@@ -56,6 +59,7 @@ start_if_needed
 				"start_if_needed",
 				"function start_if_needed",
 				"exec $WM_CMD",
+				"HERDR_ENV",
 			},
 		},
 		{
@@ -80,6 +84,7 @@ start_if_needed
 				"WM_VAR=\"$ZELLIJ\"",
 				"WM_CMD=\"zellij\"",
 				"start_if_needed",
+				"HERDR_ENV",
 			},
 			wantNotContain: []string{
 				"WM_VAR=\"/$TMUX\"",
@@ -95,6 +100,7 @@ start_if_needed
 				"WM_VAR=\"/$TMUX\"",
 				"WM_CMD=\"tmux\"",
 				"start_if_needed",
+				"HERDR_ENV",
 			},
 			wantNotContain: []string{},
 		},
@@ -274,7 +280,7 @@ let MULTIPLEXER = "tmux"
 let MULTIPLEXER_ENV_PREFIX = "TMUX"
 
 def start_multiplexer [] {
-  if $MULTIPLEXER_ENV_PREFIX not-in ($env | columns) {
+  if ($MULTIPLEXER_ENV_PREFIX not-in ($env | columns)) and ("HERDR_ENV" not-in ($env | columns)) {
     run-external $MULTIPLEXER
   }
 }
@@ -301,6 +307,7 @@ start_multiplexer
 				"def start_multiplexer",
 				"start_multiplexer",
 				"run-external",
+				"HERDR_ENV",
 			},
 		},
 		{
@@ -310,6 +317,7 @@ start_multiplexer
 				"let MULTIPLEXER = \"zellij\"",
 				"let MULTIPLEXER_ENV_PREFIX = \"ZELLIJ\"",
 				"start_multiplexer",
+				"HERDR_ENV",
 			},
 			wantNotContain: []string{
 				"let MULTIPLEXER = \"tmux\"",
@@ -323,6 +331,7 @@ start_multiplexer
 				"let MULTIPLEXER = \"tmux\"",
 				"let MULTIPLEXER_ENV_PREFIX = \"TMUX\"",
 				"start_multiplexer",
+				"HERDR_ENV",
 			},
 			wantNotContain: []string{},
 		},


### PR DESCRIPTION
Closes #164

## What

Adds a `HERDR_ENV` guard to the multiplexer auto-launch logic across the
zsh, fish and nushell configs, so tmux/zellij does not auto-start inside
[herdr](https://github.com/ogulcancelik/herdr) panes.

## Why

herdr is an agent multiplexer that runs each pane as a real shell on top of
your terminal. Since the Gentleman configs auto-launch tmux/zellij on
interactive startup, an unguarded config spawns a multiplexer *inside* every
herdr pane — nesting one multiplexer in another and breaking the pane.

herdr exports `HERDR_ENV` in its panes, so the auto-launch now skips when that
variable is set. The guard is multiplexer-agnostic, so it covers both tmux and
zellij with a single condition.

## Changes

- **zsh** (`GentlemanZsh/.zshrc`) — `start_if_needed` adds `[[ -z "$HERDR_ENV" ]]`
- **fish** (`GentlemanFish/fish/config.fish`) — launch block wrapped in `if not set -q HERDR_ENV`
- **nushell** (`GentlemanNushell/config.nu`) — `start_multiplexer` adds `"HERDR_ENV" not-in ($env | columns)`
- **docs** (`docs/manual-installation.md`) — new Troubleshooting entry explaining the guard
- **tests** (`installer/internal/system/patch_test.go`) — assert the guard survives
  tmux/zellij patching and is removed in `none` mode (zsh + nushell)

## How it works with the installer

The configs are patched at install time by `PatchZshForWM` / `PatchNushellForWM`.
The guard lives inside the auto-launch function body, so it is preserved as-is in
tmux/zellij mode and removed together with the block in `none` mode — no Go changes
needed.

## Testing

- `go test ./internal/system/ -run WM -v` → all pass
- `zsh -n GentlemanZsh/.zshrc` → OK

## Known limitation (out of scope)

The fish guard is not covered by a test yet. `PatchFishForWM` is already stale
relative to the current nested `config.fish` (it expects the old commented ZELLIJ
block), so on `--wm=zellij` / `--wm=none` it leaves an orphan `end`. Fixing that
patcher and adding the fish test will be a separate PR.