### PR TITLE
fix(installer): prefer native package managers with brew fallback on failure

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -607,17 +607,38 @@ type platformPackages struct {
 }
 
 func installPlatformPackages(m *Model, stepID string, packages platformPackages, onLog func(string)) *system.ExecResult {
+	// Prefer native package manager on Linux, fall back to Homebrew if available
 	switch {
 	case m.SystemInfo.IsTermux:
 		return system.RunPkgInstall(packages.Termux, nil, onLog)
-	case m.SystemInfo.OS == system.OSArch && !m.SystemInfo.HasBrew && packages.Arch != "":
-    		return system.RunSudoWithLogs("pacman -S --needed --noconfirm "+packages.Arch, nil, onLog)
-	case m.SystemInfo.OS == system.OSFedora && !m.SystemInfo.HasBrew && packages.Fedora != "":
-    		return system.RunSudoWithLogs("dnf install -y "+packages.Fedora, nil, onLog)
-	case (m.SystemInfo.OS == system.OSDebian || m.SystemInfo.OS == system.OSLinux) && !m.SystemInfo.HasBrew && packages.Debian != "":
-		return system.RunSudoWithLogs("apt-get install -y "+packages.Debian, nil, onLog)
-	default:
+	case m.SystemInfo.OS == system.OSArch && packages.Arch != "":
+		result := system.RunSudoWithLogs("pacman -S --needed --noconfirm "+packages.Arch, nil, onLog)
+		if result.Error == nil || !m.SystemInfo.HasBrew || packages.Brew == "" {
+			return result
+		}
+		// Native failed, fall back to Homebrew
 		return system.RunBrewWithLogs("install "+packages.Brew, nil, onLog)
+	case m.SystemInfo.OS == system.OSFedora && packages.Fedora != "":
+		result := system.RunSudoWithLogs("dnf install -y "+packages.Fedora, nil, onLog)
+		if result.Error == nil || !m.SystemInfo.HasBrew || packages.Brew == "" {
+			return result
+		}
+		// Native failed, fall back to Homebrew
+		return system.RunBrewWithLogs("install "+packages.Brew, nil, onLog)
+	case (m.SystemInfo.OS == system.OSDebian || m.SystemInfo.OS == system.OSLinux) && packages.Debian != "":
+		result := system.RunSudoWithLogs("apt-get install -y "+packages.Debian, nil, onLog)
+		if result.Error == nil || !m.SystemInfo.HasBrew || packages.Brew == "" {
+			return result
+		}
+		// Native failed, fall back to Homebrew
+		return system.RunBrewWithLogs("install "+packages.Brew, nil, onLog)
+	default:
+		if m.SystemInfo.HasBrew && packages.Brew != "" {
+			return system.RunBrewWithLogs("install "+packages.Brew, nil, onLog)
+		}
+		return &system.ExecResult{
+			Error: fmt.Errorf("no package manager available for this platform"),
+		}
 	}
 }
 

--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -610,10 +610,10 @@ func installPlatformPackages(m *Model, stepID string, packages platformPackages,
 	switch {
 	case m.SystemInfo.IsTermux:
 		return system.RunPkgInstall(packages.Termux, nil, onLog)
-	case m.SystemInfo.OS == system.OSArch && packages.Arch != "":
-		return system.RunSudoWithLogs("pacman -S --needed --noconfirm "+packages.Arch, nil, onLog)
-	case m.SystemInfo.OS == system.OSFedora && packages.Fedora != "":
-		return system.RunSudoWithLogs("dnf install -y "+packages.Fedora, nil, onLog)
+	case m.SystemInfo.OS == system.OSArch && !m.SystemInfo.HasBrew && packages.Arch != "":
+    		return system.RunSudoWithLogs("pacman -S --needed --noconfirm "+packages.Arch, nil, onLog)
+	case m.SystemInfo.OS == system.OSFedora && !m.SystemInfo.HasBrew && packages.Fedora != "":
+    		return system.RunSudoWithLogs("dnf install -y "+packages.Fedora, nil, onLog)
 	case (m.SystemInfo.OS == system.OSDebian || m.SystemInfo.OS == system.OSLinux) && !m.SystemInfo.HasBrew && packages.Debian != "":
 		return system.RunSudoWithLogs("apt-get install -y "+packages.Debian, nil, onLog)
 	default:


### PR DESCRIPTION
Closes #166

## Summary

- Native package managers (pacman, dnf, apt) now run **first**, regardless of whether Homebrew is installed.
- If the native install fails **and** Homebrew is available with packages defined, it falls back to brew gracefully.
- The default case now checks `HasBrew && Brew != ""` before running brew, and returns a clear error if no package manager is available.

## Changes

| File | Change |
|------|--------|
| `installer/internal/tui/installer.go` | Replaced `!HasBrew` guard with native-first + brew fallback pattern |

## Test Plan

- [x] Compiles without errors: `go build ./...`
- [x] All installation tests pass: `go test ./internal/tui/ -run "TestInstall"`
- [x] System tests pass: `go test ./internal/system/`

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers