### PR TITLE
fix(installer): clean partial backups on failure

### DIFF
--- a/installer/internal/system/exec.go
+++ b/installer/internal/system/exec.go
@@ -445,6 +445,13 @@ func CreateBackup(configs []string) (string, error) {
 		return "", fmt.Errorf("failed to create backup directory: %w", err)
 	}
 
+	cleanupOnFailure := true
+	defer func() {
+		if cleanupOnFailure {
+			_ = os.RemoveAll(backupDir)
+		}
+	}()
+
 	configPaths := ConfigPaths()
 
 	for _, configKey := range configs {
@@ -481,6 +488,7 @@ func CreateBackup(configs []string) (string, error) {
 		}
 	}
 
+	cleanupOnFailure = false
 	return backupDir, nil
 }
 

--- a/installer/internal/system/exec_test.go
+++ b/installer/internal/system/exec_test.go
@@ -437,6 +437,35 @@ func TestCreateBackup(t *testing.T) {
 	})
 }
 
+func TestCreateBackupRemovesPartialBackupOnFailure(t *testing.T) {
+	home := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("Failed to set HOME: %v", err)
+	}
+	defer os.Setenv("HOME", originalHome)
+
+	nvimDir := filepath.Join(home, ".config", "nvim")
+	if err := os.MkdirAll(nvimDir, 0o755); err != nil {
+		t.Fatalf("Failed to create nvim config dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(home, "missing-target"), filepath.Join(nvimDir, "broken-link")); err != nil {
+		t.Skipf("Symlinks not supported in this environment: %v", err)
+	}
+
+	backupDir, err := CreateBackup([]string{"nvim"})
+	if err == nil {
+		defer os.RemoveAll(backupDir)
+		t.Fatal("Expected backup to fail for broken symlink")
+	}
+	if backupDir == "" {
+		t.Fatal("Expected backup path to be returned with the error")
+	}
+	if _, statErr := os.Stat(backupDir); !os.IsNotExist(statErr) {
+		t.Fatalf("Expected partial backup %s to be removed, stat error: %v", backupDir, statErr)
+	}
+}
+
 func TestRestoreBackup(t *testing.T) {
 	t.Run("should error for non-existent backup", func(t *testing.T) {
 		err := RestoreBackup("/non/existent/backup")


### PR DESCRIPTION
Fixes #153

## PR Type
- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance/tooling (`type:chore`)

## Summary
- Removes partial backup directories when backup creation fails.
- Adds regression coverage for backup cleanup on failed copy.

## Changes
| File | Change |
|------|--------|
| `installer/internal/system/exec.go` | Cleans the newly-created backup directory unless backup creation completes successfully. |
| `installer/internal/system/exec_test.go` | Adds coverage for failed backup cleanup using a broken symlink. |

## Test Plan
- [x] `cd installer && go test ./internal/system/ -run 'TestCreateBackup'`
- [x] `cd installer && go test ./internal/system/`
- [x] `cd installer && go test ./...`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts, not applicable
- [x] Docs updated if behavior changed, not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
