### PR TITLE
fix(installer): separate AUR packages from official packages on Arch Linux

### DIFF
--- a/installer/internal/system/detect.go
+++ b/installer/internal/system/detect.go
@@ -20,17 +20,19 @@ const (
 )
 
 type SystemInfo struct {
-	OS        OSType
-	OSName    string
-	IsWSL     bool
-	IsARM     bool
-	IsTermux  bool
-	HomeDir   string
-	HasBrew   bool
-	HasPkg    bool // Termux package manager
-	HasXcode  bool
-	UserShell string
-	Prefix    string // Termux $PREFIX or empty for other systems
+	OS            OSType
+	OSName        string
+	IsWSL         bool
+	IsARM         bool
+	IsTermux      bool
+	HomeDir       string
+	HasBrew       bool
+	HasPkg        bool // Termux package manager
+	HasXcode      bool
+	HasAURHelper  bool   // true if yay or paru is installed
+	AURHelper     string // "yay" or "paru" (empty if none)
+	UserShell     string
+	Prefix        string // Termux $PREFIX or empty for other systems
 }
 
 func Detect() *SystemInfo {
@@ -66,6 +68,7 @@ func Detect() *SystemInfo {
 		if isArchLinux() {
 			info.OS = OSArch
 			info.OSName = "Arch Linux"
+			info.HasAURHelper, info.AURHelper = detectAURHelper()
 		} else if isFedora() {
 			info.OS = OSFedora
 			info.OSName = "Fedora/RHEL"
@@ -139,6 +142,17 @@ func checkPkg() bool {
 func checkBrew() bool {
 	_, err := exec.LookPath("brew")
 	return err == nil
+}
+
+// detectAURHelper checks for yay or paru (Arch User Repository helpers)
+func detectAURHelper() (bool, string) {
+	if _, err := exec.LookPath("yay"); err == nil {
+		return true, "yay"
+	}
+	if _, err := exec.LookPath("paru"); err == nil {
+		return true, "paru"
+	}
+	return false, ""
 }
 
 func checkXcode() bool {

--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -599,17 +599,19 @@ func stepInstallFont(m *Model) error {
 }
 
 type platformPackages struct {
-	Termux string
-	Brew   string
-	Arch   string
-	Fedora string
-	Debian string
+	Termux  string
+	Brew    string
+	Arch    string   // Official Arch packages (pacman)
+	ArchAUR string   // AUR packages (yay/paru)
+	Fedora  string
+	Debian  string
 }
 
 var (
 	runPkgInstallWithLogs = system.RunPkgInstall
 	runSudoWithLogs       = system.RunSudoWithLogs
 	runBrewWithLogs       = system.RunBrewWithLogs
+	runWithLogs           = system.RunWithLogs
 )
 
 func installPlatformPackages(m *Model, stepID string, packages platformPackages, onLog func(string)) *system.ExecResult {
@@ -617,7 +619,27 @@ func installPlatformPackages(m *Model, stepID string, packages platformPackages,
 	case m.SystemInfo.IsTermux:
 		return runPkgInstallWithLogs(packages.Termux, nil, onLog)
 	case m.SystemInfo.OS == system.OSArch && packages.Arch != "":
-		return runNativeWithBrewFallback("pacman -S --needed --noconfirm "+packages.Arch, packages.Brew, m.SystemInfo.HasBrew, onLog)
+		// Install official Arch packages with pacman
+		result := runNativeWithBrewFallback("pacman -S --needed --noconfirm "+packages.Arch, packages.Brew, m.SystemInfo.HasBrew, onLog)
+		if result.Error != nil {
+			return result
+		}
+		// Install AUR packages if any
+		if packages.ArchAUR != "" {
+			if !m.SystemInfo.HasAURHelper {
+				return &system.ExecResult{
+					Error: fmt.Errorf("AUR packages required (%s) but no AUR helper found. Install yay or paru first: https://wiki.archlinux.org/title/AUR_helpers", packages.ArchAUR),
+				}
+			}
+			aurCmd := m.SystemInfo.AURHelper + " -S --needed --noconfirm " + packages.ArchAUR
+			onLog(fmt.Sprintf("Installing AUR packages with %s...", m.SystemInfo.AURHelper))
+			// yay/paru handle sudo internally, do NOT use runSudoWithLogs
+			result = runWithLogs(aurCmd, nil, onLog)
+			if result.Error != nil {
+				return result
+			}
+		}
+		return result
 	case m.SystemInfo.OS == system.OSFedora && packages.Fedora != "":
 		return runNativeWithBrewFallback("dnf install -y "+packages.Fedora, packages.Brew, m.SystemInfo.HasBrew, onLog)
 	case (m.SystemInfo.OS == system.OSDebian || m.SystemInfo.OS == system.OSLinux) && !m.SystemInfo.HasBrew && packages.Debian != "":
@@ -715,11 +737,12 @@ func stepInstallShell(m *Model) error {
 	case "fish":
 		SendLog(stepID, "Installing Fish shell and plugins...")
 		result := installPlatformPackages(m, stepID, platformPackages{
-			Termux: "fish starship zoxide",
-			Brew:   "fish carapace zoxide atuin starship",
-			Arch:   "fish carapace zoxide atuin starship",
-			Fedora: "fish carapace zoxide atuin starship",
-			Debian: "fish zoxide starship",
+			Termux:  "fish starship zoxide",
+			Brew:    "fish carapace zoxide atuin starship",
+			Arch:    "fish zoxide atuin starship",
+			ArchAUR: "carapace",
+			Fedora:  "fish carapace zoxide atuin starship",
+			Debian:  "fish zoxide starship",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})
@@ -770,11 +793,12 @@ func stepInstallShell(m *Model) error {
 	case "zsh":
 		SendLog(stepID, "Installing Zsh and plugins...")
 		result := installPlatformPackages(m, stepID, platformPackages{
-			Termux: "zsh starship zoxide",
-			Brew:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
-			Arch:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
-			Fedora: "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
-			Debian: "zsh zoxide starship zsh-autosuggestions zsh-syntax-highlighting",
+			Termux:  "zsh starship zoxide",
+			Brew:    "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
+			Arch:    "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete",
+			ArchAUR: "carapace zsh-theme-powerlevel10k",
+			Fedora:  "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
+			Debian:  "zsh zoxide starship zsh-autosuggestions zsh-syntax-highlighting",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})
@@ -826,11 +850,12 @@ func stepInstallShell(m *Model) error {
 	case "nushell":
 		SendLog(stepID, "Installing Nushell and dependencies...")
 		result := installPlatformPackages(m, stepID, platformPackages{
-			Termux: "nushell starship zoxide jq",
-			Brew:   "nushell carapace zoxide atuin jq bash starship",
-			Arch:   "nushell carapace zoxide atuin jq bash starship",
-			Fedora: "nushell carapace zoxide atuin jq bash starship",
-			Debian: "nushell zoxide jq bash starship",
+			Termux:  "nushell starship zoxide jq",
+			Brew:    "nushell carapace zoxide atuin jq bash starship",
+			Arch:    "nushell zoxide atuin jq bash starship",
+			ArchAUR: "carapace",
+			Fedora:  "nushell carapace zoxide atuin jq bash starship",
+			Debian:  "nushell zoxide jq bash starship",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})


### PR DESCRIPTION
Closes #176

## Summary

- Add AUR helper detection (yay/paru) in detect.go
- Split package lists into official (pacman) and AUR (yay/paru) in installer.go
- Install AUR packages without sudo (helpers handle privileges internally)

## Changes

| File | Change |
|------|--------|
| `installer/internal/system/detect.go` | Added AUR helper detection (yay/paru) |
| `installer/internal/tui/installer.go` | Separated official vs AUR packages, added conditional installation logic |

## What was the problem?

The installer was trying to install AUR-only packages (carapace, zsh-theme-powerlevel10k) using `sudo pacman -S`, which fails because these packages dont exist in official Arch repositories.

## The solution

1. Detect if yay/paru is installed
2. Separate packages into official (pacman) and AUR (yay/paru) lists
3. Install AUR packages using the helper without sudo (they handle privileges internally)