### PR TITLE
fix(installer): carapace not in pacman repos on Arch

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -717,7 +717,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "fish starship zoxide",
 			Brew:   "fish carapace zoxide atuin starship",
-			Arch:   "fish carapace zoxide atuin starship",
+			Arch:   "fish zoxide atuin starship",
 			Fedora: "fish carapace zoxide atuin starship",
 			Debian: "fish zoxide starship",
 		}, func(line string) {
@@ -772,7 +772,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "zsh starship zoxide",
 			Brew:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
-			Arch:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
+			Arch:   "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
 			Fedora: "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
 			Debian: "zsh zoxide starship zsh-autosuggestions zsh-syntax-highlighting",
 		}, func(line string) {
@@ -828,7 +828,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "nushell starship zoxide jq",
 			Brew:   "nushell carapace zoxide atuin jq bash starship",
-			Arch:   "nushell carapace zoxide atuin jq bash starship",
+			Arch:   "nushell zoxide atuin jq bash starship",
 			Fedora: "nushell carapace zoxide atuin jq bash starship",
 			Debian: "nushell zoxide jq bash starship",
 		}, func(line string) {


### PR DESCRIPTION
## Problem

The Arch (pacman) shell-install step in the TUI installer fails with `target not found: carapace`, aborting the whole shell-install step on a fresh Arch Linux box before `starship.toml` or the fish config are copied.

## Root cause

The installer declares `carapace` as a pacman package in the `Arch` field of the Fish, Zsh and Nushell steps (`installer/internal/tui/installer.go`):

```go
Arch:   "fish carapace zoxide atuin starship",
```

But `carapace` is **not** in the official Arch repositories. It only exists in the AUR as `carapace` (source build) or `carapace-bin` (prebuilt; `Provides: carapace`). `pacman -S --needed --noconfirm fish carapace zoxide atuin starship` therefore errors out on `carapace` and the entire shell step is marked failed.

This is unrelated to the Brew/Fedora/Debian fields — `carapace` IS installable via Homebrew and is in the Fedora repos, so those paths work fine; only the pacman path is broken.

## Fix

Remove `carapace` from the three `Arch` fields only (Fish, Zsh, Nushell). The Brew/Fedora/Debian fields are left untouched — carapace remains installable there.

| File | Change |
|------|--------|
| `installer/internal/tui/installer.go` | Drop `carapace` from the `Arch:` field of the Fish, Zsh and Nushell `installPlatformPackages` calls |

Arch users who actually want carapace can install it from the AUR (`carapace-bin`) or via the Homebrew fallback path.

## Verification

```text
$ cd installer && go build ./...      # ok
$ cd installer && go vet ./internal/tui/   # ok
$ cd installer && go test ./...
ok      github.com/Gentleman-Programming/Gentleman.Dots/installer/internal/tui/trainer
FAIL    github.com/Gentleman-Programming/Gentleman.Dots/installer/internal/tui
```

The single failing test (`internal/tui`) is an environmental golden-file mismatch — the golden expects `Detected: macOS` but this machine runs Arch Linux. It fails identically on pristine `main` (without this patch) and is unrelated to the change in this PR.