### PR TITLE
feat(installer): enrich brew deps for fish on Arch

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -717,7 +717,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "fish starship zoxide",
 			Brew:   "fish carapace zoxide atuin starship",
-			Arch:   "fish carapace zoxide atuin starship",
+			Arch:   "fish zoxide atuin starship",
 			Fedora: "fish carapace zoxide atuin starship",
 			Debian: "fish zoxide starship",
 		}, func(line string) {
@@ -772,7 +772,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "zsh starship zoxide",
 			Brew:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
-			Arch:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
+			Arch:   "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
 			Fedora: "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
 			Debian: "zsh zoxide starship zsh-autosuggestions zsh-syntax-highlighting",
 		}, func(line string) {
@@ -828,7 +828,7 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "nushell starship zoxide jq",
 			Brew:   "nushell carapace zoxide atuin jq bash starship",
-			Arch:   "nushell carapace zoxide atuin jq bash starship",
+			Arch:   "nushell zoxide atuin jq bash starship",
 			Fedora: "nushell carapace zoxide atuin jq bash starship",
 			Debian: "nushell zoxide jq bash starship",
 		}, func(line string) {

--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -716,8 +716,8 @@ func stepInstallShell(m *Model) error {
 		SendLog(stepID, "Installing Fish shell and plugins...")
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "fish starship zoxide",
-			Brew:   "fish carapace zoxide atuin starship",
-			Arch:   "fish zoxide atuin starship",
+			Brew:   "fish fisher starship zoxide atuin fzf carapace nvm rustup-init coreutils",
+			Arch:   "",
 			Fedora: "fish carapace zoxide atuin starship",
 			Debian: "fish zoxide starship",
 		}, func(line string) {


### PR DESCRIPTION
> **Depends on #178 (stacked).** Once #178 merges, GitHub will auto-resolve this PR to show only the Fish-block Brew enrichment + Arch-empty change. Until then the diff appears to include the carapace removal from Fish/Zsh/Nushell Arch — that is intentional (this branch is built on top of #178) and will disappear automatically.

## Problem

Two coupled issues for the Fish shell installation path:

1. The README documents `brew install fish fisher starship zoxide atuin fzf carapace nvm rustup-init coreutils` as the full set of fish dependencies on macOS/Linux (`README.md` §2.3). The installer's `Brew` field only listed `fish carapace zoxide atuin starship`, so **fisher, fzf, coreutils, nvm, and rustup-init** were silently skipped — users had to install them manually post-install to get the documented fish experience.
2. On Arch, the fish-shell path is meant to go through Homebrew (`README.md` §2.3 — `.tmux.conf` hard-codes `/home/linuxbrew/.linuxbrew/bin/fish` as the default shell), but the installer still tried `pacman -S fish …`, producing a partial install that doesn't match what the README describes.

## Root cause

`installer/internal/tui/installer.go` (Fish block):

```go
Termux: "fish starship zoxide",
Brew:   "fish carapace zoxide atuin starship",   // ← README lists more
Arch:   "fish zoxide atuin starship",             // ← should let brew fall through
Fedora: "fish carapace zoxide atuin starship",
```

The `Brew` field is missing five packages from the README's documented list (fisher, fzf, coreutils, nvm, rustup-init). The `Arch` field non-empty value makes `runNativeWithBrewFallback` run pacman first and treat the native install as success, never reaching brew.

## Fix

Two field changes, Fish shell block only:

| Field | Before | After |
|------|--------|-------|
| `Brew` | `fish carapace zoxide atuin starship` | `fish fisher starship zoxide atuin fzf carapace nvm rustup-init coreutils` (matches README) |
| `Arch` | `fish zoxide atuin starship` | `""` (empty → brew fallback) |

Zsh and Nushell blocks are **untouched**. Their Brew fields (which already include carapace) and their Arch fields (which already exclude carapace after #178) remain unchanged.

## Verification

```text
$ cd installer && go build ./...      # ok
$ cd installer && go vet ./internal/tui/   # ok
$ cd installer && go test ./...
ok      github.com/Gentleman-Programming/Gentleman.Dots/installer/internal/tui/trainer
FAIL    github.com/Gentleman-Programming/Gentleman.Dots/installer/internal/tui
```

The single failing test (`internal/tui`) is an **environmental** golden-file mismatch — the golden expects `Detected: macOS` but this machine runs Arch Linux. It fails identically on pristine `main` and on the base of #178 (without either patch). Unrelated to this PR.

## Stacking note

- Built directly on top of #178 (`fix/arch-carapace-package-not-found`).
- If a maintainer prefers this un-stacked, I can rebase onto `main` — but then the carapace removal from the Fish Arch field would reappear in this diff until #178 lands. Stacking is the cleaner story here.