### PR TITLE
fix(installer): fall back to GitHub when packages are missing from native repos

### DIFF
--- a/installer/internal/tui/installer.go
+++ b/installer/internal/tui/installer.go
@@ -1,9 +1,13 @@
 package tui
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -604,12 +608,14 @@ type platformPackages struct {
 	Arch   string
 	Fedora string
 	Debian string
+	GitHub string
 }
 
 var (
 	runPkgInstallWithLogs = system.RunPkgInstall
 	runSudoWithLogs       = system.RunSudoWithLogs
 	runBrewWithLogs       = system.RunBrewWithLogs
+	runCheckCommand       = system.Run
 )
 
 func installPlatformPackages(m *Model, stepID string, packages platformPackages, onLog func(string)) *system.ExecResult {
@@ -617,11 +623,11 @@ func installPlatformPackages(m *Model, stepID string, packages platformPackages,
 	case m.SystemInfo.IsTermux:
 		return runPkgInstallWithLogs(packages.Termux, nil, onLog)
 	case m.SystemInfo.OS == system.OSArch && packages.Arch != "":
-		return runNativeWithBrewFallback("pacman -S --needed --noconfirm "+packages.Arch, packages.Brew, m.SystemInfo.HasBrew, onLog)
+		return installNativeWithGitHubFallback(m, stepID, packages.Arch, packages.Brew, packages.GitHub, "pacman", m.SystemInfo.HasBrew, onLog)
 	case m.SystemInfo.OS == system.OSFedora && packages.Fedora != "":
-		return runNativeWithBrewFallback("dnf install -y "+packages.Fedora, packages.Brew, m.SystemInfo.HasBrew, onLog)
+		return installNativeWithGitHubFallback(m, stepID, packages.Fedora, packages.Brew, packages.GitHub, "dnf", m.SystemInfo.HasBrew, onLog)
 	case (m.SystemInfo.OS == system.OSDebian || m.SystemInfo.OS == system.OSLinux) && !m.SystemInfo.HasBrew && packages.Debian != "":
-		return runSudoWithLogs("apt-get install -y "+packages.Debian, nil, onLog)
+		return installNativeWithGitHubFallback(m, stepID, packages.Debian, packages.Brew, packages.GitHub, "apt", false, onLog)
 	default:
 		if m.SystemInfo.HasBrew && packages.Brew != "" {
 			return runBrewWithLogs("install "+packages.Brew, nil, onLog)
@@ -632,6 +638,132 @@ func installPlatformPackages(m *Model, stepID string, packages platformPackages,
 	}
 }
 
+// installNativeWithGitHubFallback installs packages through the native package
+// manager, checking availability per package first. Native managers abort the
+// whole transaction when one package is unknown (pacman fails entirely), so
+// packages the manager does not provide are installed from GitHub instead when
+// a fallback installer exists. Availability is checked for the combined list of
+// native and GitHub packages, so a package that only ships a GitHub installer
+// (e.g. carapace) is still probed and routed to its fallback when the native
+// manager does not have it. If the availability query itself fails (e.g.
+// package manager or its database is unavailable), degrade to the previous
+// behavior: hand the full package list to the native manager.
+func installNativeWithGitHubFallback(m *Model, stepID, nativePkgs, brewPkgs, githubPkgs, pkgMgr string, hasBrew bool, onLog func(string)) *system.ExecResult {
+	existing, missing, checked := filterNativePackages(strings.TrimSpace(nativePkgs+" "+githubPkgs), pkgMgr)
+	if !checked {
+		SendLog(stepID, fmt.Sprintf("Could not verify package availability, installing all packages via %s", pkgMgr))
+		return runNativeWithBrewFallback(nativeInstallCommand(pkgMgr, strings.Fields(nativePkgs)...), brewPkgs, hasBrew, onLog)
+	}
+
+	githubSet := make(map[string]bool)
+	for _, pkg := range strings.Fields(githubPkgs) {
+		githubSet[pkg] = true
+	}
+
+	for _, pkg := range missing {
+		if !githubSet[pkg] {
+			return &system.ExecResult{Error: fmt.Errorf("package %q is not available in the system repositories and has no GitHub fallback installer", pkg)}
+		}
+	}
+
+	var nativeResult *system.ExecResult
+	if len(existing) > 0 {
+		nativeResult = runNativeWithBrewFallback(nativeInstallCommand(pkgMgr, existing...), brewPkgs, hasBrew, onLog)
+	}
+
+	for _, pkg := range missing {
+		if err := installGitHubPackageFn(m, stepID, pkg, onLog); err != nil {
+			return &system.ExecResult{Error: err}
+		}
+	}
+
+	if nativeResult != nil {
+		return nativeResult
+	}
+	return &system.ExecResult{}
+}
+
+// filterNativePackages splits pkgs into those the native package manager
+// provides and those it does not. checked is false when availability could not
+// be determined for any package (infrastructure failure, not a missing
+// package).
+func filterNativePackages(pkgs, pkgMgr string) (existing, missing []string, checked bool) {
+	for _, pkg := range strings.Fields(pkgs) {
+		exists, ok := packageAvailableInRepo(pkg, pkgMgr)
+		if !ok {
+			return nil, nil, false
+		}
+		if exists {
+			existing = append(existing, pkg)
+		} else {
+			missing = append(missing, pkg)
+		}
+	}
+	return existing, missing, true
+}
+
+// packageAvailableInRepo reports whether pkg exists in the native package
+// manager's repositories and whether the query itself succeeded. A failed
+// query (ok=false) means availability could not be determined, NOT that the
+// package is missing. LC_ALL=C forces English output so the "not found" marker
+// is locale-independent.
+func packageAvailableInRepo(pkg, pkgMgr string) (exists, ok bool) {
+	query := ""
+	notFoundPattern := ""
+	switch pkgMgr {
+	case "pacman":
+		query = "LC_ALL=C pacman -Si " + pkg
+		notFoundPattern = "target not found"
+	case "dnf":
+		query = "LC_ALL=C dnf info " + pkg
+		notFoundPattern = "No match for argument"
+	case "apt":
+		query = "apt-cache show " + pkg
+	default:
+		return false, false
+	}
+
+	result := runCheckCommand(query, nil)
+	if result.Error != nil && result.ExitCode == 0 {
+		// The process never started (e.g. the package manager binary is
+		// missing): availability cannot be determined.
+		return false, false
+	}
+	if result.ExitCode == 0 {
+		// Some apt versions exit 0 with empty output for unknown packages.
+		if pkgMgr == "apt" && strings.TrimSpace(result.Output) == "" {
+			return false, true
+		}
+		return true, true
+	}
+	// Non-zero exit is the manager's normal "package unknown" report, so it
+	// is NOT an infrastructure failure by itself. For pacman/dnf, only treat
+	// it as missing when the manager explicitly prints its "not found"
+	// marker; any other non-zero exit (locked database, missing metadata, no
+	// network) means availability could not be determined.
+	if notFoundPattern != "" {
+		if strings.Contains(result.Output+"\n"+result.Stderr, notFoundPattern) {
+			return false, true
+		}
+		return false, false
+	}
+	// apt-cache show: non-zero exit means the package is unknown to the cache.
+	return false, true
+}
+
+func nativeInstallCommand(pkgMgr string, pkgs ...string) string {
+	list := strings.Join(pkgs, " ")
+	switch pkgMgr {
+	case "pacman":
+		return "pacman -S --needed --noconfirm " + list
+	case "dnf":
+		return "dnf install -y " + list
+	case "apt":
+		return "apt-get install -y " + list
+	}
+	return list
+}
+
 func runNativeWithBrewFallback(nativeCommand string, brewPackages string, hasBrew bool, onLog func(string)) *system.ExecResult {
 	result := runSudoWithLogs(nativeCommand, nil, onLog)
 	if result.Error == nil || !hasBrew || brewPackages == "" {
@@ -639,6 +771,165 @@ func runNativeWithBrewFallback(nativeCommand string, brewPackages string, hasBre
 	}
 
 	return runBrewWithLogs("install "+brewPackages, nil, onLog)
+}
+
+// installGitHubPackageFn is the dispatch seam for GitHub fallback installers.
+var installGitHubPackageFn = installGitHubPackage
+
+func installGitHubPackage(m *Model, stepID, pkg string, onLog func(string)) error {
+	switch pkg {
+	case "carapace":
+		return installCarapaceBinary(m, stepID, onLog)
+	case "zsh-theme-powerlevel10k":
+		return installPowerlevel10k(m, stepID, onLog)
+	default:
+		return fmt.Errorf("no GitHub fallback installer for package %q", pkg)
+	}
+}
+
+func installCarapaceBinary(m *Model, stepID string, onLog func(string)) error {
+	if system.CommandExists("carapace") {
+		SendLog(stepID, "Carapace already installed")
+		return nil
+	}
+
+	assetArch := ""
+	switch runtime.GOARCH {
+	case "amd64":
+		assetArch = "amd64"
+	case "arm64":
+		assetArch = "arm64"
+	default:
+		return fmt.Errorf("unsupported Carapace architecture: %s", runtime.GOARCH)
+	}
+
+	homeDir := os.Getenv("HOME")
+	binDir := filepath.Join(homeDir, ".local", "bin")
+	if err := system.EnsureDir(binDir); err != nil {
+		return err
+	}
+
+	// Download to a temporary directory and clean it up afterwards.
+	tmpDir, err := os.MkdirTemp("", "carapace")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Resolve the latest release asset and its official digest from the
+	// GitHub API. The digest is the same SHA256 the project publishes in its
+	// checksums.txt file next to the installers, so no version or checksum is
+	// hardcoded here: the verification always matches the current release.
+	metaPath := filepath.Join(tmpDir, "release.json")
+	SendLog(stepID, "Resolving latest Carapace release...")
+	result := system.RunWithLogs("curl -fsSL https://api.github.com/repos/carapace-sh/carapace-bin/releases/latest -o "+metaPath, nil, onLog)
+	if result.Error != nil {
+		return result.Error
+	}
+	meta, err := os.ReadFile(metaPath)
+	if err != nil {
+		return err
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+		Assets  []struct {
+			Name   string `json:"name"`
+			URL    string `json:"browser_download_url"`
+			Digest string `json:"digest"`
+		} `json:"assets"`
+	}
+	if err := json.Unmarshal(meta, &release); err != nil {
+		return fmt.Errorf("parsing Carapace release metadata: %w", err)
+	}
+
+	assetName := fmt.Sprintf("carapace-bin_%s_linux_%s.tar.gz", strings.TrimPrefix(release.TagName, "v"), assetArch)
+	var assetURL, expectedSHA256 string
+	for _, a := range release.Assets {
+		if a.Name == assetName {
+			assetURL = a.URL
+			expectedSHA256 = strings.TrimPrefix(a.Digest, "sha256:")
+			break
+		}
+	}
+	if assetURL == "" || expectedSHA256 == "" {
+		return fmt.Errorf("no digest available for Carapace release asset %q", assetName)
+	}
+
+	tarPath := filepath.Join(tmpDir, "carapace.tar.gz")
+	SendLog(stepID, "Downloading Carapace release binary...")
+	result = system.RunWithLogs(fmt.Sprintf("curl -fsSL %q -o %q", assetURL, tarPath), nil, onLog)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	data, err := os.ReadFile(tarPath)
+	if err != nil {
+		return err
+	}
+	actualSHA256 := sha256.Sum256(data)
+	if hex.EncodeToString(actualSHA256[:]) != expectedSHA256 {
+		return fmt.Errorf("Carapace checksum mismatch for %s", assetURL)
+	}
+
+	SendLog(stepID, "Extracting Carapace binary...")
+	dest := filepath.Join(binDir, "carapace")
+	if err := extractTarGzBinary(tarPath, "carapace", dest); err != nil {
+		return err
+	}
+
+	return os.Chmod(dest, 0755)
+}
+
+// extractTarGzBinary extracts the first regular file entry whose base name
+// matches entryName from a .tar.gz archive and writes it to dest.
+func extractTarGzBinary(tarGzPath, entryName, dest string) error {
+	f, err := os.Open(tarGzPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag != tar.TypeReg || filepath.Base(hdr.Name) != entryName {
+			continue
+		}
+		out, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	}
+	return fmt.Errorf("entry %q not found in %s", entryName, tarGzPath)
+}
+
+func installPowerlevel10k(m *Model, stepID string, onLog func(string)) error {
+	if _, err := os.Stat("/usr/share/powerlevel10k/powerlevel10k.zsh-theme"); err == nil {
+		SendLog(stepID, "Powerlevel10k already installed")
+		return nil
+	}
+
+	SendLog(stepID, "Cloning Powerlevel10k from GitHub...")
+	result := runSudoWithLogs("git clone --depth 1 https://github.com/romkatv/powerlevel10k /usr/share/powerlevel10k", nil, onLog)
+	return result.Error
 }
 
 func installHerdrBinary(m *Model, stepID string) error {
@@ -717,9 +1008,10 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "fish starship zoxide",
 			Brew:   "fish carapace zoxide atuin starship",
-			Arch:   "fish carapace zoxide atuin starship",
-			Fedora: "fish carapace zoxide atuin starship",
+			Arch:   "fish zoxide atuin starship",
+			Fedora: "fish zoxide atuin starship",
 			Debian: "fish zoxide starship",
+			GitHub: "carapace",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})
@@ -772,9 +1064,10 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "zsh starship zoxide",
 			Brew:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
-			Arch:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k",
-			Fedora: "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
+			Arch:   "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete",
+			Fedora: "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting starship",
 			Debian: "zsh zoxide starship zsh-autosuggestions zsh-syntax-highlighting",
+			GitHub: "carapace zsh-theme-powerlevel10k",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})
@@ -828,9 +1121,10 @@ func stepInstallShell(m *Model) error {
 		result := installPlatformPackages(m, stepID, platformPackages{
 			Termux: "nushell starship zoxide jq",
 			Brew:   "nushell carapace zoxide atuin jq bash starship",
-			Arch:   "nushell carapace zoxide atuin jq bash starship",
-			Fedora: "nushell carapace zoxide atuin jq bash starship",
+			Arch:   "nushell zoxide atuin jq bash starship",
+			Fedora: "nushell zoxide atuin jq bash starship",
 			Debian: "nushell zoxide jq bash starship",
+			GitHub: "carapace",
 		}, func(line string) {
 			SendLog(stepID, line)
 		})

--- a/installer/internal/tui/platform_packages_test.go
+++ b/installer/internal/tui/platform_packages_test.go
@@ -1,8 +1,13 @@
 package tui
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Gentleman-Programming/Gentleman.Dots/installer/internal/system"
@@ -13,14 +18,34 @@ type packageCommandCall struct {
 	command string
 }
 
+type packageCheckResult int
+
+const (
+	checkExists packageCheckResult = iota
+	checkMissing
+	checkInfraFail
+	checkInfraExit
+)
+
 func withPackageCommandMocks(t *testing.T, sudoErr error) *[]packageCommandCall {
+	t.Helper()
+	return withPackageCommandMocksAndCheck(t, sudoErr, nil)
+}
+
+func withPackageCommandMocksAndCheck(t *testing.T, sudoErr error, check func(string) packageCheckResult) *[]packageCommandCall {
 	t.Helper()
 
 	originalPkg := runPkgInstallWithLogs
 	originalSudo := runSudoWithLogs
 	originalBrew := runBrewWithLogs
+	originalCheck := runCheckCommand
+	originalGitHub := installGitHubPackageFn
 
 	calls := []packageCommandCall{}
+
+	if check == nil {
+		check = func(string) packageCheckResult { return checkExists }
+	}
 
 	runPkgInstallWithLogs = func(packages string, opts *system.ExecOptions, onLog func(string)) *system.ExecResult {
 		calls = append(calls, packageCommandCall{runner: "pkg", command: packages})
@@ -34,14 +59,51 @@ func withPackageCommandMocks(t *testing.T, sudoErr error) *[]packageCommandCall 
 		calls = append(calls, packageCommandCall{runner: "brew", command: args})
 		return &system.ExecResult{Command: args}
 	}
+	runCheckCommand = func(command string, opts *system.ExecOptions) *system.ExecResult {
+		calls = append(calls, packageCommandCall{runner: "check", command: command})
+		pkg := checkCommandPackage(command)
+		switch check(pkg) {
+		case checkMissing:
+			// Model the real system.Run contract: a non-zero exit always
+			// carries a non-nil Error.
+			if strings.HasPrefix(command, "LC_ALL=C pacman ") || strings.HasPrefix(command, "pacman ") {
+				return &system.ExecResult{Command: command, ExitCode: 1, Error: errors.New("exit status 1"), Stderr: "error: target not found: " + pkg}
+			}
+			if strings.HasPrefix(command, "LC_ALL=C dnf ") || strings.HasPrefix(command, "dnf ") {
+				return &system.ExecResult{Command: command, ExitCode: 1, Error: errors.New("exit status 1"), Stderr: "No match for argument: " + pkg}
+			}
+			return &system.ExecResult{Command: command, ExitCode: 100, Error: errors.New("exit status 100")}
+		case checkInfraFail:
+			// Start failure: Error is set but the process never ran, so
+			// ExitCode stays 0.
+			return &system.ExecResult{Command: command, Error: errors.New("could not query package database")}
+		case checkInfraExit:
+			// The manager ran but failed without the "not found" marker
+			// (locked database, missing metadata, no network).
+			return &system.ExecResult{Command: command, ExitCode: 1, Error: errors.New("exit status 1"), Stderr: "error: failed to synchronize all databases"}
+		default:
+			return &system.ExecResult{Command: command, ExitCode: 0, Output: "Name : " + pkg}
+		}
+	}
+	installGitHubPackageFn = func(m *Model, stepID, pkg string, onLog func(string)) error {
+		calls = append(calls, packageCommandCall{runner: "github", command: pkg})
+		return nil
+	}
 
 	t.Cleanup(func() {
 		runPkgInstallWithLogs = originalPkg
 		runSudoWithLogs = originalSudo
 		runBrewWithLogs = originalBrew
+		runCheckCommand = originalCheck
+		installGitHubPackageFn = originalGitHub
 	})
 
 	return &calls
+}
+
+func checkCommandPackage(command string) string {
+	fields := strings.Fields(command)
+	return fields[len(fields)-1]
 }
 
 func TestInstallPlatformPackagesFedoraFallsBackToBrewWhenNativeFails(t *testing.T) {
@@ -50,7 +112,8 @@ func TestInstallPlatformPackagesFedoraFallsBackToBrewWhenNativeFails(t *testing.
 	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSFedora, HasBrew: true}}
 	result := installPlatformPackages(m, "shell", platformPackages{
 		Brew:   "fish carapace zoxide atuin starship",
-		Fedora: "fish carapace zoxide atuin starship",
+		Fedora: "fish zoxide atuin starship",
+		GitHub: "carapace",
 	}, nil)
 
 	if result.Error != nil {
@@ -58,7 +121,12 @@ func TestInstallPlatformPackagesFedoraFallsBackToBrewWhenNativeFails(t *testing.
 	}
 
 	expected := []packageCommandCall{
-		{runner: "sudo", command: "dnf install -y fish carapace zoxide atuin starship"},
+		{runner: "check", command: "LC_ALL=C dnf info fish"},
+		{runner: "check", command: "LC_ALL=C dnf info zoxide"},
+		{runner: "check", command: "LC_ALL=C dnf info atuin"},
+		{runner: "check", command: "LC_ALL=C dnf info starship"},
+		{runner: "check", command: "LC_ALL=C dnf info carapace"},
+		{runner: "sudo", command: "dnf install -y fish zoxide atuin starship carapace"},
 		{runner: "brew", command: "install fish carapace zoxide atuin starship"},
 	}
 	if !reflect.DeepEqual(*calls, expected) {
@@ -101,6 +169,9 @@ func TestInstallPlatformPackagesDebianWithoutBrewUsesApt(t *testing.T) {
 	}
 
 	expected := []packageCommandCall{
+		{runner: "check", command: "apt-cache show fish"},
+		{runner: "check", command: "apt-cache show zoxide"},
+		{runner: "check", command: "apt-cache show starship"},
 		{runner: "sudo", command: "apt-get install -y fish zoxide starship"},
 	}
 	if !reflect.DeepEqual(*calls, expected) {
@@ -113,8 +184,9 @@ func TestInstallPlatformPackagesArchFallsBackToBrewWhenNativeFails(t *testing.T)
 
 	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
 	result := installPlatformPackages(m, "shell", platformPackages{
-		Brew: "fish carapace zoxide atuin starship",
-		Arch: "fish carapace zoxide atuin starship",
+		Brew:   "fish carapace zoxide atuin starship",
+		Arch:   "fish zoxide atuin starship",
+		GitHub: "carapace",
 	}, nil)
 
 	if result.Error != nil {
@@ -122,10 +194,315 @@ func TestInstallPlatformPackagesArchFallsBackToBrewWhenNativeFails(t *testing.T)
 	}
 
 	expected := []packageCommandCall{
-		{runner: "sudo", command: "pacman -S --needed --noconfirm fish carapace zoxide atuin starship"},
+		{runner: "check", command: "LC_ALL=C pacman -Si fish"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zoxide"},
+		{runner: "check", command: "LC_ALL=C pacman -Si atuin"},
+		{runner: "check", command: "LC_ALL=C pacman -Si starship"},
+		{runner: "check", command: "LC_ALL=C pacman -Si carapace"},
+		{runner: "sudo", command: "pacman -S --needed --noconfirm fish zoxide atuin starship carapace"},
 		{runner: "brew", command: "install fish carapace zoxide atuin starship"},
 	}
 	if !reflect.DeepEqual(*calls, expected) {
 		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPlatformPackagesArchMissingPackageInstallsFromGitHub(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "carapace" {
+			return checkMissing
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Brew:   "fish carapace zoxide atuin starship",
+		Arch:   "fish zoxide atuin starship",
+		GitHub: "carapace",
+	}, nil)
+
+	if result.Error != nil {
+		t.Fatalf("expected success, got error: %v", result.Error)
+	}
+
+	// Availability checks run over the combined native+GitHub list (carapace
+	// is probed even though pacman is not expected to have it), the native
+	// command receives the filtered list, and the missing package is handed
+	// to the GitHub installer.
+	expected := []packageCommandCall{
+		{runner: "check", command: "LC_ALL=C pacman -Si fish"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zoxide"},
+		{runner: "check", command: "LC_ALL=C pacman -Si atuin"},
+		{runner: "check", command: "LC_ALL=C pacman -Si starship"},
+		{runner: "check", command: "LC_ALL=C pacman -Si carapace"},
+		{runner: "sudo", command: "pacman -S --needed --noconfirm fish zoxide atuin starship"},
+		{runner: "github", command: "carapace"},
+	}
+	if !reflect.DeepEqual(*calls, expected) {
+		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPlatformPackagesArchMissingPackageWithoutGitHubFallbackFails(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "atuin" {
+			return checkMissing
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Brew:   "fish carapace zoxide atuin starship",
+		Arch:   "fish zoxide atuin starship",
+		GitHub: "carapace",
+	}, nil)
+
+	if result.Error == nil {
+		t.Fatal("expected error for package without GitHub fallback")
+	}
+	if !strings.Contains(result.Error.Error(), "atuin") {
+		t.Errorf("error should mention the package name, got: %v", result.Error)
+	}
+
+	for _, call := range *calls {
+		if call.runner == "sudo" || call.runner == "github" {
+			t.Errorf("unexpected call after missing package error: %#v", call)
+		}
+	}
+}
+
+func TestInstallPlatformPackagesCheckInfrastructureFailureDegradesToNative(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "carapace" {
+			return checkInfraFail
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Brew:   "fish carapace zoxide atuin starship",
+		Arch:   "fish zoxide atuin starship",
+		GitHub: "carapace",
+	}, nil)
+
+	if result.Error != nil {
+		t.Fatalf("expected degraded native install to succeed, got error: %v", result.Error)
+	}
+
+	// When the query itself fails (the manager process never started), the
+	// full native list goes to the manager and no GitHub installer runs.
+	expected := []packageCommandCall{
+		{runner: "check", command: "LC_ALL=C pacman -Si fish"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zoxide"},
+		{runner: "check", command: "LC_ALL=C pacman -Si atuin"},
+		{runner: "check", command: "LC_ALL=C pacman -Si starship"},
+		{runner: "check", command: "LC_ALL=C pacman -Si carapace"},
+		{runner: "sudo", command: "pacman -S --needed --noconfirm fish zoxide atuin starship"},
+	}
+	if !reflect.DeepEqual(*calls, expected) {
+		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPlatformPackagesArchInfraExitWithoutPatternDegradesToNative(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "carapace" {
+			return checkInfraExit
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Brew:   "fish carapace zoxide atuin starship",
+		Arch:   "fish zoxide atuin starship",
+		GitHub: "carapace",
+	}, nil)
+
+	if result.Error != nil {
+		t.Fatalf("expected degraded native install to succeed, got error: %v", result.Error)
+	}
+
+	// A non-zero exit WITHOUT the "target not found" marker is an
+	// infrastructure failure, not a missing package: degrade to the full
+	// native list and never run the GitHub installer.
+	expected := []packageCommandCall{
+		{runner: "check", command: "LC_ALL=C pacman -Si fish"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zoxide"},
+		{runner: "check", command: "LC_ALL=C pacman -Si atuin"},
+		{runner: "check", command: "LC_ALL=C pacman -Si starship"},
+		{runner: "check", command: "LC_ALL=C pacman -Si carapace"},
+		{runner: "sudo", command: "pacman -S --needed --noconfirm fish zoxide atuin starship"},
+	}
+	if !reflect.DeepEqual(*calls, expected) {
+		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPlatformPackagesCachyosPowerlevel10kNativeCarapaceGitHub(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "carapace" {
+			return checkMissing
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSArch, HasBrew: true}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Brew:   "zsh carapace zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete powerlevel10k",
+		Arch:   "zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete",
+		GitHub: "carapace zsh-theme-powerlevel10k",
+	}, nil)
+
+	if result.Error != nil {
+		t.Fatalf("expected success, got error: %v", result.Error)
+	}
+
+	// CachyOS-style repos provide zsh-theme-powerlevel10k natively, so it
+	// lands in `existing` and is installed via pacman; carapace is missing
+	// and is routed to its GitHub installer.
+	expected := []packageCommandCall{
+		{runner: "check", command: "LC_ALL=C pacman -Si zsh"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zoxide"},
+		{runner: "check", command: "LC_ALL=C pacman -Si atuin"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zsh-autosuggestions"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zsh-syntax-highlighting"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zsh-autocomplete"},
+		{runner: "check", command: "LC_ALL=C pacman -Si carapace"},
+		{runner: "check", command: "LC_ALL=C pacman -Si zsh-theme-powerlevel10k"},
+		{runner: "sudo", command: "pacman -S --needed --noconfirm zsh zoxide atuin zsh-autosuggestions zsh-syntax-highlighting zsh-autocomplete zsh-theme-powerlevel10k"},
+		{runner: "github", command: "carapace"},
+	}
+	if !reflect.DeepEqual(*calls, expected) {
+		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPlatformPackagesDebianMissingPackageInstallsFromGitHub(t *testing.T) {
+	calls := withPackageCommandMocksAndCheck(t, nil, func(pkg string) packageCheckResult {
+		if pkg == "carapace" {
+			return checkMissing
+		}
+		return checkExists
+	})
+
+	m := &Model{SystemInfo: &system.SystemInfo{OS: system.OSDebian, HasBrew: false}}
+	result := installPlatformPackages(m, "shell", platformPackages{
+		Debian: "fish zoxide starship",
+		GitHub: "carapace",
+	}, nil)
+
+	if result.Error != nil {
+		t.Fatalf("expected success, got error: %v", result.Error)
+	}
+
+	expected := []packageCommandCall{
+		{runner: "check", command: "apt-cache show fish"},
+		{runner: "check", command: "apt-cache show zoxide"},
+		{runner: "check", command: "apt-cache show starship"},
+		{runner: "check", command: "apt-cache show carapace"},
+		{runner: "sudo", command: "apt-get install -y fish zoxide starship"},
+		{runner: "github", command: "carapace"},
+	}
+	if !reflect.DeepEqual(*calls, expected) {
+		t.Fatalf("calls = %#v, want %#v", *calls, expected)
+	}
+}
+
+func TestInstallPowerlevel10k(t *testing.T) {
+	if _, err := os.Stat("/usr/share/powerlevel10k/powerlevel10k.zsh-theme"); err == nil {
+		t.Skip("Powerlevel10k already installed on this system")
+	}
+
+	originalSudo := runSudoWithLogs
+	defer func() { runSudoWithLogs = originalSudo }()
+
+	var gotCommand string
+	runSudoWithLogs = func(command string, opts *system.ExecOptions, onLog system.LogCallback) *system.ExecResult {
+		gotCommand = command
+		return &system.ExecResult{Command: command}
+	}
+
+	m := &Model{SystemInfo: &system.SystemInfo{}}
+	if err := installPowerlevel10k(m, "shell", nil); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	want := "git clone --depth 1 https://github.com/romkatv/powerlevel10k /usr/share/powerlevel10k"
+	if gotCommand != want {
+		t.Errorf("command = %q, want %q", gotCommand, want)
+	}
+}
+
+func TestExtractTarGzBinary(t *testing.T) {
+	t.Run("extracts the binary entry", func(t *testing.T) {
+		dir := t.TempDir()
+		tarGzPath := filepath.Join(dir, "release.tar.gz")
+		writeTestTarGz(t, tarGzPath)
+
+		dest := filepath.Join(dir, "carapace")
+		if err := extractTarGzBinary(tarGzPath, "carapace", dest); err != nil {
+			t.Fatalf("extract failed: %v", err)
+		}
+
+		data, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("failed to read extracted binary: %v", err)
+		}
+		if string(data) != "binary-content" {
+			t.Errorf("extracted content = %q, want %q", string(data), "binary-content")
+		}
+	})
+
+	t.Run("fails when the entry is missing", func(t *testing.T) {
+		dir := t.TempDir()
+		tarGzPath := filepath.Join(dir, "release.tar.gz")
+		writeTestTarGz(t, tarGzPath)
+
+		err := extractTarGzBinary(tarGzPath, "missing", filepath.Join(dir, "out"))
+		if err == nil {
+			t.Fatal("expected error for missing entry")
+		}
+	})
+}
+
+func writeTestTarGz(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create archive: %v", err)
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	entries := []struct {
+		name    string
+		content string
+	}{
+		{"LICENSE", "MIT\n"},
+		{"carapace", "binary-content"},
+		{"README.md", "carapace release\n"},
+	}
+	for _, entry := range entries {
+		hdr := &tar.Header{
+			Name: entry.name,
+			Mode: 0755,
+			Size: int64(len(entry.content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("failed to write header: %v", err)
+		}
+		if _, err := tw.Write([]byte(entry.content)); err != nil {
+			t.Fatalf("failed to write entry: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes the shell install steps (fish/zsh/nushell) on Arch/Fedora/Debian when a package is not available in the native package manager repositories.
- The installer now checks per-package availability against the native manager (`pacman -Si` / `dnf info` / `apt-cache show`) before running the install transaction, which previously aborted entirely when a single package was unknown.
- Packages the native manager cannot provide are installed from GitHub instead: `carapace` (binary from carapace-bin releases, verified against the official asset digest from the GitHub API — the same SHA256 the project publishes in its checksums.txt) and `zsh-theme-powerlevel10k` (cloned to `/usr/share/powerlevel10k`, a path the bundled `.zshrc` already sources).

## Motivation

On vanilla Arch and Fedora, `carapace` is not in the official repositories, and `zsh-theme-powerlevel10k` is only present in some repositories (e.g. CachyOS). Running `pacman -S --needed --noconfirm fish carapace zoxide atuin starship` fails entirely with `error: no se ha encontrado el paquete: carapace`, aborting the whole shell install step.

The runtime availability check means distros that DO provide the packages (CachyOS provides `zsh-theme-powerlevel10k`) install them natively; others fall back to GitHub — no hardcoding per distro and no AUR helper dependency.

## Changes

| File | Change |
|------|--------|
| `installer/internal/tui/installer.go` | Add `GitHub` field to `platformPackages`; per-package availability check (`packageAvailableInRepo`) with graceful degrade to the native manager; `installNativeWithGitHubFallback`; `installCarapaceBinary` (latest release resolved via GitHub API, verified against the official digest); `installPowerlevel10k`; tar.gz binary extraction helper. |
| `installer/internal/tui/platform_packages_test.go` | Mocks now model the real `system.Run` contract; tests for missing→GitHub, CachyOS-style native p10k, infra degrade, apt quirks, missing-without-fallback error, and brew fallback. |

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./installer/... -skip 'Golden'` passes (TestOSSelectGolden is a pre-existing environmental failure on Linux — the golden was generated on macOS; it fails on `main` without this change too)
- [x] End-to-end: carapace asset download + digest verification against the official GitHub API digest
- [x] Manual validation on real CachyOS: `fish` step installs `carapace` from GitHub and the `zsh` step installs `zsh-theme-powerlevel10k` natively from the cachyos repo; installer completes successfully
