### PR TITLE
fix(shell): tmux session mirroring, PATH sanitization, and tooling fixes

### DIFF
--- a/GentlemanFish/fish/config.fish
+++ b/GentlemanFish/fish/config.fish
@@ -1,9 +1,9 @@
 if status is-interactive
     # Commands to run in interactive sessions can go here
-    # Install Fisher if not installed
+    # Install Fisher if not installed (git.io was shut down by GitHub in 2023)
     if not functions -q fisher
-        curl -sL https://git.io/fisher | source
-        fisher install jorgebucaran/fisher
+        curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source
+        and fisher install jorgebucaran/fisher
     end
 
 end
@@ -26,11 +26,11 @@ else if test (uname) = Darwin
         # Intel Mac
         set BREW_BIN /usr/local/bin/brew
     end
-    set -x PATH $HOME/.local/bin $HOME/.opencode/bin $HOME/.volta/bin $HOME/.bun/bin $HOME/.nix-profile/bin /nix/var/nix/profiles/default/bin /usr/local/bin $HOME/.config $HOME/.cargo/bin /usr/local/lib/* $PATH
+    set -x PATH $HOME/.local/bin $HOME/.opencode/bin $HOME/.volta/bin $HOME/.bun/bin $HOME/.nix-profile/bin /nix/var/nix/profiles/default/bin /usr/local/bin $HOME/.cargo/bin $PATH
 else
     # Linux
     set BREW_BIN /home/linuxbrew/.linuxbrew/bin/brew
-    set -x PATH $HOME/.local/bin $HOME/.opencode/bin $HOME/.volta/bin $HOME/.bun/bin $HOME/.nix-profile/bin /nix/var/nix/profiles/default/bin /usr/local/bin $HOME/.config $HOME/.cargo/bin /usr/local/lib/* $PATH
+    set -x PATH $HOME/.local/bin $HOME/.opencode/bin $HOME/.volta/bin $HOME/.bun/bin $HOME/.nix-profile/bin /nix/var/nix/profiles/default/bin /usr/local/bin $HOME/.cargo/bin $PATH
 end
 
 # Only eval brew shellenv if brew is installed (not on Termux)
@@ -48,8 +48,6 @@ starship init fish | source
 zoxide init fish | source
 atuin init fish | source
 fzf --fish | source
-
-set -x PATH $HOME/.cargo/bin $PATH
 
 # Carapace completions
 set -Ux CARAPACE_BRIDGES 'zsh,fish,bash,inshellisense'
@@ -76,6 +74,9 @@ fish_vi_key_bindings
 # Set nvim as default editor for opencode and other tools
 set -gx EDITOR nvim
 set -gx VISUAL nvim
+
+# Use bat as the man page pager
+set -gx MANPAGER "sh -c 'col -bx | bat -l man -p'"
 
 ## alias
 if test (uname) = Darwin
@@ -119,4 +120,3 @@ set -g fish_pager_color_progress $comment
 set -g fish_pager_color_prefix $cyan
 set -g fish_pager_color_completion $foreground
 set -g fish_pager_color_description $comment
-clear

--- a/GentlemanTmux/tmux.conf
+++ b/GentlemanTmux/tmux.conf
@@ -27,6 +27,9 @@ bind-key -n M-g if-shell -F '#{==:#{session_name},scratch}' {
   display-popup -d "#{pane_current_path}" -E -k "tmux new-session -A -s scratch"
 }
 
+# Lazygit floating window
+bind-key -n M-l display-popup -d "#{pane_current_path}" -E -k "lazygit"
+
 # Tema Kanagawa
 set -g @plugin 'Nybkox/tmux-kanagawa'
 set -g @kanagawa-theme 'dragon'
@@ -71,6 +74,9 @@ bind K confirm-before -p "Kill all other sessions? (y/n)" "kill-session -a"
 # Fix index
 set -g base-index 1
 setw -g pane-base-index 1
+
+# Scrollback history per pane (default is only 2000 lines)
+set -g history-limit 100000
 
 # TPM init
 run '~/.tmux/plugins/tpm/tpm'

--- a/installer/internal/system/exec.go
+++ b/installer/internal/system/exec.go
@@ -848,7 +848,8 @@ func fishMultiplexerBlock(wm string) []string {
 		return []string{
 			"# Start selected terminal multiplexer",
 			"if status is-interactive; and command -q tmux; and not set -q TMUX; and not set -q ZELLIJ; and not set -q HERDR_ENV",
-			"    tmux new-session -A -s main",
+			"    # Create a unique session per terminal window (-A would attach to an existing session instead, mirroring it across terminals)",
+			"    tmux new-session -s \"term-$(date +%s)-$(random)\"",
 			"end",
 		}
 	}

--- a/installer/internal/system/patch_test.go
+++ b/installer/internal/system/patch_test.go
@@ -249,9 +249,11 @@ alias fzfbat='fzf --preview="bat --theme=gruvbox-dark --color=always {}"'
 			installNvim: true,
 			wantContain: []string{
 				"command -q tmux",
+				"tmux new-session -s \"term-$(date +%s)-$(random)\"",
+			},
+			wantNotContain: []string{
 				"tmux new-session -A -s main",
 			},
-			wantNotContain: []string{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Five fixes found while debugging a real user environment where every new terminal window mirrored the previous one (same tmux session attached twice).

## Changes

### GentlemanFish/fish/config.fish
1. **Fisher bootstrap was dead**: `git.io` shortlinks were shut down by GitHub in 2023, so first-run plugin installation silently failed. Replaced with the official `raw.githubusercontent.com` URL and chained with `and`.
2. **Unsafe PATH entries**: removed $HOME/.config and glob-expanded /usr/local/lib/* from PATH (both make arbitrary non-executable content resolvable as commands), plus a duplicated $HOME/.cargo/bin append.
3. **bat as MANPAGER**: bat is already installed by these dotfiles; man pages now render with syntax highlighting.
4. **Removed trailing `clear`** so shell startup errors are visible.

### GentlemanTmux/tmux.conf
5. **Session mirroring fix**: `tmux new-session -A -s main` attaches every new terminal to the same session — windows become mirrors of each other with synced changes. Each interactive shell now creates its own uniquely named session (`term-<epoch>-<random>`).
6. **history-limit 100000** (default is only 2000 lines per pane).
7. **M-l lazygit popup**, following the existing M-g scratch popup pattern.

### installer/internal/system
- Updated `fishMultiplexerBlock` accordingly: without this, `PatchFishForWM` would regenerate the old `-A -s main` block on every install and reintroduce the mirroring behavior.
- Updated `TestPatchFishForWM` expectation to assert the new invocation AND that the old one is gone.

## Verification

- `go test ./internal/system/ -count=1` in installer/ ✅
- `fish -n config.fish` syntax check ✅